### PR TITLE
Fix tile size consistency

### DIFF
--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -1,8 +1,15 @@
 .tile {
   background-color: #333;
   color: white;
-  padding: 20px;
+  padding: 10px;
   position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  aspect-ratio: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 .tile.possible {
   outline: 2px solid yellow;


### PR DESCRIPTION
## Summary
- adjust `.tile` styling so revealed or hidden tiles stay the same size

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844717e6624832685df235c4dda8fae