### PR TITLE
Add hero stats and canvas portrait

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project aims to build a digital adaptation of the board game **Tiny Epic Dungeon** using JavaScript and React.
 
+The current version includes a simple hero portrait generated with the HTML canvas and displays additional hero statistics.
+
 ## Getting Started
 
 1. Install dependencies:
@@ -29,4 +31,6 @@ This project aims to build a digital adaptation of the board game **Tiny Epic Du
   - HP
   - Activity points
   - Attack power
-  - Defence power
+- Defence power
+
+The hero panel now displays these attributes along with a small picture drawn on a canvas element.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,10 @@ import './App.css'
 const BOARD_SIZE = 7
 const CENTER = Math.floor(BOARD_SIZE / 2)
 const START_MOVEMENT = 3
+const START_HP = 10
+const START_AP = 2
+const START_ATTACK = 3
+const START_DEFENCE = 1
 
 const DIRS = ['up', 'down', 'left', 'right']
 
@@ -56,6 +60,18 @@ function loadState() {
           })
         )
       }
+      if (parsed.hero) {
+        parsed.hero = {
+          row: parsed.hero.row,
+          col: parsed.hero.col,
+          movement: parsed.hero.movement ?? START_MOVEMENT,
+          icon: parsed.hero.icon ?? 'H',
+          hp: parsed.hero.hp ?? START_HP,
+          ap: parsed.hero.ap ?? START_AP,
+          attack: parsed.hero.attack ?? START_ATTACK,
+          defence: parsed.hero.defence ?? START_DEFENCE,
+        }
+      }
       return parsed
     } catch {
       /* ignore corrupted save */
@@ -71,7 +87,16 @@ function loadState() {
   }
   return {
     board,
-    hero: { row: CENTER, col: CENTER, movement: START_MOVEMENT, icon: 'H' },
+    hero: {
+      row: CENTER,
+      col: CENTER,
+      movement: START_MOVEMENT,
+      icon: 'H',
+      hp: START_HP,
+      ap: START_AP,
+      attack: START_ATTACK,
+      defence: START_DEFENCE,
+    },
     deck: Array.from({ length: 60 }, (_, i) => i + 1),
   }
 }
@@ -134,7 +159,12 @@ function App() {
         return
       }
 
-      const newHero = { ...hero, row: r, col: c, movement: hero.movement - 1 }
+      const newHero = {
+        ...hero,
+        row: r,
+        col: c,
+        movement: hero.movement - 1,
+      }
       setState({ board: newBoard, hero: newHero, deck: newDeck })
     },
     [state]

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -1,13 +1,39 @@
 import React from 'react'
 import './HeroPanel.css'
 
+function drawHeroPicture(canvas) {
+  if (!canvas) return
+  const ctx = canvas.getContext('2d')
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+  ctx.fillStyle = '#222'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+  ctx.fillStyle = '#f0c060'
+  ctx.beginPath()
+  ctx.arc(50, 30, 20, 0, Math.PI * 2)
+  ctx.fill()
+
+  ctx.fillStyle = '#c04040'
+  ctx.fillRect(35, 60, 30, 30)
+}
+
 function HeroPanel({ hero }) {
   return (
     <div className="hero-panel">
       <h2>Hero Attributes</h2>
+      <canvas
+        width="100"
+        height="100"
+        ref={c => drawHeroPicture(c)}
+        style={{ display: 'block', margin: '0 auto 10px' }}
+      />
       <p>Icon: {hero.icon}</p>
       <p>Position: ({hero.row}, {hero.col})</p>
       <p>Movement: {hero.movement}</p>
+      <p>HP: {hero.hp}</p>
+      <p>AP: {hero.ap}</p>
+      <p>Attack: {hero.attack}</p>
+      <p>Defence: {hero.defence}</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- implement extra hero attributes (hp, ap, attack, defence)
- ensure saved state is migrated
- render hero picture in hero panel via canvas
- document new hero details

## Testing
- `npm install`
- `npm install` in `frontend`
- `npm run build` in `frontend`
- `node server.js` *(manually stopped)*

------
https://chatgpt.com/codex/tasks/task_e_684471df38a08326a4f54ec52832e75c