### PR TITLE
Separate hero data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ The current version includes a simple hero portrait generated with the HTML canv
 - Defence power
 
 The hero panel now displays these attributes along with a small picture drawn on a canvas element.
+
+### Customizing Hero Stats
+
+Default hero values such as movement and health are defined in
+`frontend/src/heroData.js`. Edit this file to tweak the starting
+attributes without touching the game logic.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,14 +3,17 @@ import RoomTile from './components/RoomTile'
 import HeroPanel from './components/HeroPanel'
 import { ROOM_DECK } from './roomDeck'
 import './App.css'
+import {
+  START_MOVEMENT,
+  START_HP,
+  START_AP,
+  START_ATTACK,
+  START_DEFENCE,
+  HERO_ICON,
+} from './heroData'
 
 const BOARD_SIZE = 7
 const CENTER = Math.floor(BOARD_SIZE / 2)
-const START_MOVEMENT = 3
-const START_HP = 10
-const START_AP = 2
-const START_ATTACK = 3
-const START_DEFENCE = 1
 
 const DIRS = ['up', 'down', 'left', 'right']
 
@@ -66,7 +69,7 @@ function loadState() {
           row: parsed.hero.row,
           col: parsed.hero.col,
           movement: parsed.hero.movement ?? START_MOVEMENT,
-          icon: parsed.hero.icon ?? 'H',
+          icon: parsed.hero.icon ?? HERO_ICON,
           hp: parsed.hero.hp ?? START_HP,
           ap: parsed.hero.ap ?? START_AP,
           attack: parsed.hero.attack ?? START_ATTACK,
@@ -92,7 +95,7 @@ function loadState() {
       row: CENTER,
       col: CENTER,
       movement: START_MOVEMENT,
-      icon: 'H',
+      icon: HERO_ICON,
       hp: START_HP,
       ap: START_AP,
       attack: START_ATTACK,

--- a/frontend/src/heroData.js
+++ b/frontend/src/heroData.js
@@ -1,0 +1,6 @@
+export const START_MOVEMENT = 3
+export const START_HP = 10
+export const START_AP = 2
+export const START_ATTACK = 3
+export const START_DEFENCE = 1
+export const HERO_ICON = 'H'


### PR DESCRIPTION
## Summary
- move starting hero stats to `frontend/src/heroData.js`
- import hero stats from App
- document how to adjust hero data

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_684476e9a6148326a103bdde5084b690