### PR TITLE
Add reset game button

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -31,6 +31,10 @@
   width: 100%;
 }
 
+.reset-game {
+  width: 100%;
+}
+
 @media (max-width: 600px) {
   #root {
     padding: 1rem;
@@ -43,6 +47,9 @@
     width: 100%;
   }
   .end-turn {
+    width: 100%;
+  }
+  .reset-game {
     width: 100%;
   }
   .hero-panel {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -127,6 +127,11 @@ function App() {
     })
   }, [])
 
+  const resetGame = useCallback(() => {
+    localStorage.removeItem('dungeon-state')
+    setState(loadState())
+  }, [])
+
   const moveHero = useCallback(
     (r, c) => {
       const { hero, board, deck } = state
@@ -212,7 +217,7 @@ function App() {
   }, [state.hero, moveHero])
 
   if (!state.hero) {
-    return <HeroSelect onSelect={chooseHero} />
+    return <HeroSelect onSelect={chooseHero} onReset={resetGame} />
   }
 
   return (
@@ -237,6 +242,7 @@ function App() {
         <div className="side">
           <HeroPanel hero={state.hero} />
           <button onClick={endTurn} className="end-turn">End Turn</button>
+          <button onClick={resetGame} className="reset-game">Reset Game</button>
         </div>
       </div>
     </>

--- a/frontend/src/components/HeroSelect.jsx
+++ b/frontend/src/components/HeroSelect.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { HERO_TYPES } from '../heroData'
 import './HeroSelect.css'
 
-function HeroSelect({ onSelect }) {
+function HeroSelect({ onSelect, onReset }) {
   return (
     <div className="hero-select">
       <h2>Select Your Hero</h2>
@@ -13,6 +13,9 @@ function HeroSelect({ onSelect }) {
           </button>
         ))}
       </div>
+      <button onClick={onReset} className="reset-game" style={{ marginTop: '1rem' }}>
+        Reset Game
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `resetGame` callback to wipe local storage and reload default state
- show Reset Game button in the hero selection screen and in the side panel
- style the new button

## Testing
- `npm run lint --prefix frontend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68447dee4aa08326a55cea071d901e39