### PR TITLE
Remove hero coordinates from panel

### DIFF
--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -30,10 +30,6 @@ function HeroPanel({ hero }) {
       <div className="stats">
         <div className="label">Icon</div>
         <div>{hero.icon}</div>
-        <div className="label">Pos</div>
-        <div>
-          ({hero.row}, {hero.col})
-        </div>
         <div className="label">Move</div>
         <div>{hero.movement}</div>
         <div className="label">HP</div>


### PR DESCRIPTION
## Summary
- hide hero position info

## Testing
- `npm run lint --prefix frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68448283c2c88326aff97ef174978267