### PR TITLE
Add goblin encounter support

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import HeroSelect from './components/HeroSelect'
 import { ROOM_DECK } from './roomDeck'
 import './App.css'
 import { HERO_TYPES } from './heroData'
+import { GOBLIN_TYPES, randomGoblinType } from './goblinData'
 
 const BOARD_SIZE = 7
 const CENTER = Math.floor(BOARD_SIZE / 2)
@@ -34,6 +35,22 @@ function opposite(dir) {
   }
 }
 
+function fightGoblin(hero, goblin) {
+  let heroHp = hero.hp
+  let goblinHp = goblin.hp
+  const heroDmg = Math.max(1, hero.attack - goblin.defence)
+  const goblinDmg = Math.max(1, goblin.attack - hero.defence)
+
+  goblinHp -= heroDmg
+  if (goblinHp > 0) {
+    heroHp -= goblinDmg
+  }
+  return {
+    hero: { ...hero, hp: heroHp },
+    goblin: { ...goblin, hp: goblinHp },
+  }
+}
+
 function createEmptyBoard() {
   return Array.from({ length: BOARD_SIZE }, (_, r) =>
     Array.from({ length: BOARD_SIZE }, (_, c) => ({
@@ -42,6 +59,7 @@ function createEmptyBoard() {
       roomId: null,
       revealed: false,
       paths: { up: false, down: false, left: false, right: false },
+      goblin: null,
     }))
   )
 }
@@ -55,6 +73,7 @@ function loadState() {
         parsed.board.forEach(row =>
           row.forEach(tile => {
             if (!tile.paths) tile.paths = { up: false, down: false, left: false, right: false }
+            if (!('goblin' in tile)) tile.goblin = null
           })
         )
       }
@@ -85,6 +104,7 @@ function loadState() {
     roomId: 'Start',
     revealed: true,
     paths: { up: true, down: true, left: true, right: true },
+    goblin: null,
   }
   return {
     board,
@@ -157,22 +177,39 @@ function App() {
         const paths = { ...room.paths }
         paths[incoming] = true
 
+        let goblin = null
+        if (room.goblin) {
+          const typeKey = room.goblin === 'king' ? 'king' : randomGoblinType()
+          goblin = { ...GOBLIN_TYPES[typeKey], type: typeKey }
+        }
+
         newBoard[r][c] = {
           row: r,
           col: c,
           roomId,
           revealed: true,
           paths,
+          goblin,
         }
       } else if (!target.paths[opposite(dir)]) {
         return
       }
 
-      const newHero = {
+      let newHero = {
         ...hero,
         row: r,
         col: c,
         movement: hero.movement - 1,
+      }
+
+      if (newBoard[r][c].goblin) {
+        const result = fightGoblin(newHero, newBoard[r][c].goblin)
+        newHero = result.hero
+        if (result.goblin.hp <= 0) {
+          newBoard[r][c].goblin = null
+        } else {
+          newBoard[r][c].goblin = result.goblin
+        }
       }
       setState({ board: newBoard, hero: newHero, deck: newDeck })
     },

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -79,6 +79,13 @@
   transform: translateY(-50%);
 }
 
+.goblin-icon {
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+  font-size: 0.7rem;
+}
+
 .room-name {
   width: 100%;
   text-align: center;

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -23,6 +23,9 @@ function RoomTile({ tile, hero, onClick, highlight }) {
           )}
         </div>
       )}
+      {tile.revealed && tile.goblin && (
+        <span className="goblin-icon">{tile.goblin.icon}</span>
+      )}
       {heroHere && (
         <div className="hero-wrapper">
           <Hero hero={hero} />

--- a/frontend/src/goblinData.js
+++ b/frontend/src/goblinData.js
@@ -1,0 +1,43 @@
+export const GOBLIN_TYPES = {
+  knife: {
+    name: 'Knife Goblin',
+    hp: 3,
+    attack: 2,
+    defence: 1,
+    icon: 'K',
+  },
+  archer: {
+    name: 'Archer Goblin',
+    hp: 2,
+    attack: 3,
+    defence: 1,
+    icon: 'A',
+  },
+  spear: {
+    name: 'Spear Goblin',
+    hp: 4,
+    attack: 3,
+    defence: 2,
+    icon: 'S',
+  },
+  mage: {
+    name: 'Mage Goblin',
+    hp: 2,
+    attack: 4,
+    defence: 1,
+    icon: 'M',
+  },
+  king: {
+    name: 'Goblin King',
+    hp: 6,
+    attack: 4,
+    defence: 3,
+    icon: 'G',
+  },
+}
+
+export function randomGoblinType(includeKing = false) {
+  const keys = Object.keys(GOBLIN_TYPES).filter(k => includeKing || k !== 'king')
+  const idx = Math.floor(Math.random() * keys.length)
+  return keys[idx]
+}

--- a/frontend/src/roomDeck.js
+++ b/frontend/src/roomDeck.js
@@ -17,6 +17,18 @@ const BASE_PATHS = [
   { up: false, down: false, left: false, right: false },
 ]
 
+const GOBLIN_ROOMS = Array.from({ length: 19 }, (_, i) => ({
+  roomId: `Goblin Lair ${i + 1}`,
+  paths: BASE_PATHS[i % BASE_PATHS.length],
+  goblin: true,
+}))
+
+GOBLIN_ROOMS.push({
+  roomId: 'Goblin King\'s Den',
+  paths: BASE_PATHS[0],
+  goblin: 'king',
+})
+
 export const ROOM_DECK = [
   { roomId: 'Chamber of Bones', paths: BASE_PATHS[0] },
   { roomId: 'Chamber of Doom', paths: BASE_PATHS[1] },
@@ -88,4 +100,5 @@ export const ROOM_DECK = [
   { roomId: 'Vault of Shadows', paths: BASE_PATHS[3] },
   { roomId: 'Vault of Trials', paths: BASE_PATHS[4] },
   { roomId: 'Vault of Whispers', paths: BASE_PATHS[0] },
+  ...GOBLIN_ROOMS,
 ]


### PR DESCRIPTION
## Summary
- add goblin definitions and helper
- extend room deck with 20 goblin rooms
- show goblin icon on revealed rooms
- spawn and fight goblins when rooms are revealed

## Testing
- `npm run lint --prefix frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844825e7348832686ae163b0f020686