### PR TITLE
Enhance room tiles with card styling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8,7 +8,7 @@
 .board {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 4px;
+  gap: 0;
   width: min(90vmin, 600px);
   margin: 0 auto;
 }

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -15,7 +15,7 @@
   overflow: hidden;
 }
 .tile.possible {
-  outline: 2px solid yellow;
+  box-shadow: inset 0 0 0 2px yellow;
   cursor: pointer;
 }
 .tile.revealed {

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -20,6 +20,7 @@
 }
 .tile.revealed {
   background-color: #555;
+  border-color: #aaa;
 }
 
 .hero-wrapper {
@@ -52,8 +53,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 90%;
-  height: 90%;
+  width: 95%;
+  height: 95%;
   background-color: #aaa;
   transform: translate(-50%, -50%);
 }
@@ -66,7 +67,7 @@
 .door-up {
   top: 0;
   left: 50%;
-  width: 6px;
+  width: 50%;
   height: 50%;
   transform: translateX(-50%);
 }
@@ -74,7 +75,7 @@
 .door-down {
   bottom: 0;
   left: 50%;
-  width: 6px;
+  width: 50%;
   height: 50%;
   transform: translateX(-50%);
 }
@@ -83,7 +84,7 @@
   left: 0;
   top: 50%;
   width: 50%;
-  height: 6px;
+  height: 50%;
   transform: translateY(-50%);
 }
 
@@ -91,7 +92,7 @@
   right: 0;
   top: 50%;
   width: 50%;
-  height: 6px;
+  height: 50%;
   transform: translateY(-50%);
 }
 

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -52,8 +52,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 12px;
-  height: 12px;
+  width: 90%;
+  height: 90%;
   background-color: #aaa;
   transform: translate(-50%, -50%);
 }

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -1,11 +1,12 @@
 .tile {
   background-color: #333;
   color: white;
-  padding: 10px;
+  padding: 0;
   position: relative;
   box-sizing: border-box;
   width: 100%;
   aspect-ratio: 1;
+  border: 1px solid #777;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -32,12 +33,27 @@
   inset: 0;
 }
 
+.card-back {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-image: repeating-linear-gradient(
+    45deg,
+    #222,
+    #222 10px,
+    #333 10px,
+    #333 20px
+  );
+}
+
 .center {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 8px;
-  height: 8px;
+  width: 12px;
+  height: 12px;
   background-color: #aaa;
   transform: translate(-50%, -50%);
 }
@@ -50,7 +66,7 @@
 .door-up {
   top: 0;
   left: 50%;
-  width: 4px;
+  width: 6px;
   height: 50%;
   transform: translateX(-50%);
 }
@@ -58,7 +74,7 @@
 .door-down {
   bottom: 0;
   left: 50%;
-  width: 4px;
+  width: 6px;
   height: 50%;
   transform: translateX(-50%);
 }
@@ -67,7 +83,7 @@
   left: 0;
   top: 50%;
   width: 50%;
-  height: 4px;
+  height: 6px;
   transform: translateY(-50%);
 }
 
@@ -75,7 +91,7 @@
   right: 0;
   top: 50%;
   width: 50%;
-  height: 4px;
+  height: 6px;
   transform: translateY(-50%);
 }
 

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -37,6 +37,7 @@
 .card-back {
   position: absolute;
   inset: 0;
+  margin: 1px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -53,8 +54,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 95%;
-  height: 95%;
+  width: 90%;
+  height: 90%;
   background-color: #aaa;
   transform: translate(-50%, -50%);
 }

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -12,7 +12,11 @@ function RoomTile({ tile, hero, onClick, highlight }) {
       onClick={onClick}
       title={tile.revealed ? tile.roomId : undefined}
     >
-      {!tile.revealed && <span className="room-name">?</span>}
+      {!tile.revealed && (
+        <div className="card-back">
+          <span className="room-name">?</span>
+        </div>
+      )}
       {tile.revealed && (
         <div className="room-graphic">
           <div className="center" />


### PR DESCRIPTION
## Summary
- show unrevealed rooms with a patterned card back
- remove padding from tiles and add a border
- make room centre and exits larger

## Testing
- `npm run lint --prefix frontend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68448d37f9dc8326bd06f26a480b9054