### PR TITLE
Display room name when revealed

### DIFF
--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -100,9 +100,14 @@
 }
 
 .room-name {
+  position: absolute;
+  bottom: 2px;
+  left: 0;
+  right: 0;
   width: 100%;
   text-align: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  pointer-events: none;
 }

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -10,11 +10,7 @@ function RoomTile({ tile, onClick, highlight }) {
       onClick={onClick}
       title={tile.revealed ? tile.roomId : undefined}
     >
-      {!tile.revealed && (
-        <div className="card-back">
-          <span className="room-name">?</span>
-        </div>
-      )}
+      {!tile.revealed && <div className="card-back" />}
       {tile.revealed && (
         <div className="room-graphic">
           <div className="center" />
@@ -28,6 +24,7 @@ function RoomTile({ tile, onClick, highlight }) {
       {tile.revealed && tile.goblin && (
         <span className="goblin-icon">{tile.goblin.icon}</span>
       )}
+      {tile.revealed && <span className="room-name">{tile.roomId}</span>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show the room title in revealed rooms
- remove `?` text from unrevealed rooms
- style room name to overlay at the bottom

## Testing
- `npm run lint --prefix frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b478c6988326906b03c045eb3458