### PR TITLE
Update hero panel UI with icons

### DIFF
--- a/frontend/public/boot.svg
+++ b/frontend/public/boot.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M12 40 H48 L52 56 H12 Z" fill="#ccc" stroke="#444"/>
+  <path d="M20 8 L36 40 H12 V24 Z" fill="#eee" stroke="#444"/>
+</svg>

--- a/frontend/public/dice.svg
+++ b/frontend/public/dice.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="8" y="8" width="48" height="48" rx="6" fill="#fff" stroke="#333"/>
+  <circle cx="24" cy="24" r="4" fill="#333" />
+  <circle cx="40" cy="40" r="4" fill="#333" />
+  <circle cx="24" cy="40" r="4" fill="#333" />
+  <circle cx="40" cy="24" r="4" fill="#333" />
+</svg>

--- a/frontend/public/heart.svg
+++ b/frontend/public/heart.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M32 58 L12 38 A14 14 0 0 1 32 14 A14 14 0 0 1 52 38 Z" fill="#e66" stroke="#a22"/>
+</svg>

--- a/frontend/public/star.svg
+++ b/frontend/public/star.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <polygon points="32,6 40,26 60,26 44,38 50,58 32,46 14,58 20,38 4,26 24,26" fill="#ff6" stroke="#aa3"/>
+</svg>

--- a/frontend/public/wing.svg
+++ b/frontend/public/wing.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M6 32 Q20 6 42 12 L58 22 Q32 36 26 58 Z" fill="#cdf" stroke="#69c"/>
+</svg>

--- a/frontend/src/components/EncounterModal.jsx
+++ b/frontend/src/components/EncounterModal.jsx
@@ -80,7 +80,7 @@ function EncounterModal({ goblin, hero, onFight, onFlee }) {
         <div className="stats">
           <div className="label">HP</div>
           <div>{goblin.hp}</div>
-          <div className="label">Atk</div>
+          <div className="label">STR</div>
           <div>{goblin.attack}</div>
           <div className="label">Def</div>
           <div>{goblin.defence}</div>

--- a/frontend/src/components/HeroPanel.css
+++ b/frontend/src/components/HeroPanel.css
@@ -22,8 +22,16 @@
   font-size: 0.75em;
 }
 
+
 .label {
   text-align: right;
+  opacity: 0.8;
+}
+
+.label-icon {
+  width: 12px;
+  height: 12px;
+  justify-self: end;
   opacity: 0.8;
 }
 

--- a/frontend/src/components/HeroPanel.css
+++ b/frontend/src/components/HeroPanel.css
@@ -28,12 +28,6 @@
   opacity: 0.8;
 }
 
-.label-icon {
-  width: 12px;
-  height: 12px;
-  justify-self: end;
-  opacity: 0.8;
-}
 
 .weapons {
   display: flex;

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -14,34 +14,44 @@ function HeroPanel({ hero }) {
         style={{ display: 'block', margin: '0 auto 8px' }}
       />
       <div className="stats">
-        <div className="label">Icon</div>
-        <div>{hero.icon}</div>
-        <div className="label">Move</div>
+        <img src="/boot.svg" alt="move" className="label-icon" />
         <div>{hero.movement}</div>
-        <div className="label">HP</div>
+        <img src="/heart.svg" alt="hp" className="label-icon" />
         <div>{hero.hp}</div>
-        <div className="label">AP</div>
+        <img src="/star.svg" alt="ap" className="label-icon" />
         <div>{hero.ap}</div>
-        <div className="label">Atk</div>
+        <img src="/fist.svg" alt="strength" className="label-icon" />
         <div className="icons">
           {Array.from({ length: hero.attack }, (_, i) => (
-            <img key={i} src="/fist.svg" alt="attack" className="stat-icon" />
+            <img key={i} src="/fist.svg" alt="strength" className="stat-icon" />
           ))}
         </div>
-        <div className="label">Def</div>
+        <img src="/shield.svg" alt="defence" className="label-icon" />
         <div className="icons">
           {Array.from({ length: hero.defence }, (_, i) => (
             <img key={i} src="/shield.svg" alt="defence" className="stat-icon" />
           ))}
         </div>
-        <div className="label">Agi</div>
+        <img src="/wing.svg" alt="agility" className="label-icon" />
         <div>{hero.agility}</div>
-        <div className="label">Strength Dice</div>
-        <div>{hero.strengthDice}</div>
-        <div className="label">Agility Dice</div>
-        <div>{hero.agilityDice}</div>
-        <div className="label">Magic Dice</div>
-        <div>{hero.magicDice}</div>
+        <img src="/dice.svg" alt="strength dice" className="label-icon" />
+        <div className="icons">
+          {Array.from({ length: hero.strengthDice }, (_, i) => (
+            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
+          ))}
+        </div>
+        <img src="/dice.svg" alt="agility dice" className="label-icon" />
+        <div className="icons">
+          {Array.from({ length: hero.agilityDice }, (_, i) => (
+            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
+          ))}
+        </div>
+        <img src="/dice.svg" alt="magic dice" className="label-icon" />
+        <div className="icons">
+          {Array.from({ length: hero.magicDice }, (_, i) => (
+            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
+          ))}
+        </div>
       </div>
       <div className="weapons">
         {hero.weapons.map((w, idx) => (

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -14,47 +14,55 @@ function HeroPanel({ hero }) {
         style={{ display: 'block', margin: '0 auto 8px' }}
       />
       <div className="stats">
-        <img src="/boot.svg" alt="move" className="label-icon" />
-        <div>{hero.movement}</div>
-        <img src="/heart.svg" alt="hp" className="label-icon" />
+        <div className="label">Move</div>
+        <div className="icons">
+          {Array.from({ length: hero.movement }, (_, i) => (
+            <img key={i} src="/boot.svg" alt="move" className="stat-icon" />
+          ))}
+        </div>
+        <div className="label">HP</div>
         <div className="icons">
           {Array.from({ length: hero.hp }, (_, i) => (
             <img key={i} src="/heart.svg" alt="hp" className="stat-icon" />
           ))}
         </div>
-        <img src="/star.svg" alt="ap" className="label-icon" />
+        <div className="label">AP</div>
         <div className="icons">
           {Array.from({ length: hero.ap }, (_, i) => (
             <img key={i} src="/star.svg" alt="ap" className="stat-icon" />
           ))}
         </div>
-        <img src="/fist.svg" alt="strength" className="label-icon" />
+        <div className="label">STR</div>
         <div className="icons">
           {Array.from({ length: hero.attack }, (_, i) => (
             <img key={i} src="/fist.svg" alt="strength" className="stat-icon" />
           ))}
         </div>
-        <img src="/shield.svg" alt="defence" className="label-icon" />
+        <div className="label">Def</div>
         <div className="icons">
           {Array.from({ length: hero.defence }, (_, i) => (
             <img key={i} src="/shield.svg" alt="defence" className="stat-icon" />
           ))}
         </div>
-        <img src="/wing.svg" alt="agility" className="label-icon" />
-        <div>{hero.agility}</div>
-        <img src="/dice.svg" alt="strength dice" className="label-icon" />
+        <div className="label">Agi</div>
+        <div className="icons">
+          {Array.from({ length: hero.agility }, (_, i) => (
+            <img key={i} src="/wing.svg" alt="agility" className="stat-icon" />
+          ))}
+        </div>
+        <div className="label">STR Dice</div>
         <div className="icons">
           {Array.from({ length: hero.strengthDice }, (_, i) => (
             <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
           ))}
         </div>
-        <img src="/dice.svg" alt="agility dice" className="label-icon" />
+        <div className="label">Agi Dice</div>
         <div className="icons">
           {Array.from({ length: hero.agilityDice }, (_, i) => (
             <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
           ))}
         </div>
-        <img src="/dice.svg" alt="magic dice" className="label-icon" />
+        <div className="label">Magic Dice</div>
         <div className="icons">
           {Array.from({ length: hero.magicDice }, (_, i) => (
             <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -17,9 +17,17 @@ function HeroPanel({ hero }) {
         <img src="/boot.svg" alt="move" className="label-icon" />
         <div>{hero.movement}</div>
         <img src="/heart.svg" alt="hp" className="label-icon" />
-        <div>{hero.hp}</div>
+        <div className="icons">
+          {Array.from({ length: hero.hp }, (_, i) => (
+            <img key={i} src="/heart.svg" alt="hp" className="stat-icon" />
+          ))}
+        </div>
         <img src="/star.svg" alt="ap" className="label-icon" />
-        <div>{hero.ap}</div>
+        <div className="icons">
+          {Array.from({ length: hero.ap }, (_, i) => (
+            <img key={i} src="/star.svg" alt="ap" className="stat-icon" />
+          ))}
+        </div>
         <img src="/fist.svg" alt="strength" className="label-icon" />
         <div className="icons">
           {Array.from({ length: hero.attack }, (_, i) => (


### PR DESCRIPTION
## Summary
- redesign hero panel stats grid with icon-only labels
- remove hero icon row from panel
- rename Atk to STR in encounter modal
- show dice stats using dice icons
- add simple SVG icons for boot, dice, heart, star and wing

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6844b53216a48326b352fde5f81fec8a