### PR TITLE
Fix attack when no base die rolled

### DIFF
--- a/frontend/src/components/EncounterModal.jsx
+++ b/frontend/src/components/EncounterModal.jsx
@@ -125,7 +125,9 @@ function EncounterModal({ goblin, hero, onFight, onFlee }) {
             </div>
             <div className="info">
               {baseIdx === null
-                ? 'Choose a base die (>=3).'
+                ? rolls.some(v => v >= 3)
+                  ? 'Choose a base die (>=3).'
+                  : 'No die is high enough for a base roll.'
                 : (() => {
                     const details = computeAttackBreakdown(
                       hero,
@@ -140,7 +142,12 @@ function EncounterModal({ goblin, hero, onFight, onFlee }) {
                   })()}
             </div>
             <div className="buttons">
-              <button onClick={confirmFight} disabled={baseIdx === null}>Attack</button>
+              <button
+                onClick={confirmFight}
+                disabled={rolls.some(v => v >= 3) && baseIdx === null}
+              >
+                Attack
+              </button>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- let players attack even if no die value is high enough to become the base
- show message when there is no selectable base

## Testing
- `npm run lint --prefix frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844bd1cec78832693c4a5c44b5ba102