### PR TITLE
Highlight traps and explain disarming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ The current version shows a hero portrait drawn in a Hearthstone‑style. Each h
 
 The hero panel now displays these attributes along with a portrait image for the selected hero.
 
+### Trap Disarming
+
+When you enter a room with a trap you may attempt to disarm it. Roll your hero's
+*agility* dice (shown in the hero panel). If any die comes up **4** or higher the
+trap is disarmed and you receive a random treasure. Failure removes the trap but
+grants no reward, so knowing your agility dice helps decide whether to disarm or
+move on. Unresolved trap rooms are highlighted in red with a warning icon so you
+can easily spot them on the board.
+
 ### Customizing Hero Stats
 
 Starting values for each hero type can be modified in

--- a/frontend/src/components/EncounterModal.css
+++ b/frontend/src/components/EncounterModal.css
@@ -65,6 +65,11 @@
   margin-bottom: 0.5rem;
 }
 
+.trap-info {
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
 .label {
   text-align: right;
   opacity: 0.8;

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -23,6 +23,23 @@
   border-color: #aaa;
 }
 
+.tile.trap-room {
+  background-color: #663333;
+  border-color: #ff6666;
+}
+
+.tile.trap-room .center,
+.tile.trap-room .door {
+  background-color: #ff9999;
+}
+
+.trap-icon {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 0.7rem;
+}
+
 
 .room-graphic {
   position: absolute;

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -1,14 +1,23 @@
 import React from 'react'
 import './RoomTile.css'
+import { DISARM_RULE } from '../trapRules'
 
 const DIRS = ['up', 'down', 'left', 'right']
 
 function RoomTile({ tile, onClick, highlight }) {
   return (
     <div
-      className={`tile ${tile.revealed ? 'revealed' : ''} ${highlight ? 'possible' : ''}`}
+      className={`tile ${tile.revealed ? 'revealed' : ''} ${highlight ? 'possible' : ''} ${
+        tile.revealed && tile.trap && !tile.trapResolved ? 'trap-room' : ''
+      }`}
       onClick={onClick}
-      title={tile.revealed ? tile.roomId : undefined}
+      title={
+        tile.revealed
+          ? `${tile.roomId}${
+              tile.trap && !tile.trapResolved ? ' - ' + DISARM_RULE : ''
+            }`
+          : undefined
+      }
     >
       {!tile.revealed && <div className="card-back" />}
       {tile.revealed && (
@@ -23,6 +32,9 @@ function RoomTile({ tile, onClick, highlight }) {
       )}
       {tile.revealed && tile.goblin && (
         <span className="goblin-icon">{tile.goblin.icon}</span>
+      )}
+      {tile.revealed && tile.trap && !tile.trapResolved && (
+        <span className="trap-icon" title={DISARM_RULE}>⚠️</span>
       )}
       {tile.revealed && <span className="room-name">{tile.roomId}</span>}
     </div>

--- a/frontend/src/components/TrapModal.jsx
+++ b/frontend/src/components/TrapModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import './EncounterModal.css'
+import { DISARM_RULE } from '../trapRules'
 
 function TrapModal({ hero, onResolve }) {
   const [rolls, setRolls] = useState([])
@@ -20,9 +21,12 @@ function TrapModal({ hero, onResolve }) {
       <div className="encounter-window">
         <h2>Trap!</h2>
         {rolls.length === 0 && (
-          <div className="buttons">
-            <button onClick={attempt}>Disarm</button>
-          </div>
+          <>
+            <p className="trap-info">{DISARM_RULE}</p>
+            <div className="buttons">
+              <button onClick={attempt}>Disarm</button>
+            </div>
+          </>
         )}
         {rolls.length > 0 && (
           <div className="fight-stage">

--- a/frontend/src/trapRules.js
+++ b/frontend/src/trapRules.js
@@ -1,0 +1,1 @@
+export const DISARM_RULE = "Roll your hero's agility dice. Any die that shows 4 or more disarms the trap.";


### PR DESCRIPTION
## Summary
- clarify traps by displaying disarm rule in TrapModal
- show warning icon on trap rooms with new red styling
- mention new trap visuals in README

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6844bd5e52808326812fcf244e010dfb