### PR TITLE
Improve trap handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,7 @@ The hero panel now displays these attributes along with a portrait image for the
 ### Trap Disarming
 
 When you enter a room with a trap you may attempt to disarm it. Roll your hero's
-*agility* dice (shown in the hero panel). If any die comes up **4** or higher the
-trap is disarmed and you receive a random treasure. Failure removes the trap but
-grants no reward, so knowing your agility dice helps decide whether to disarm or
-move on. Unresolved trap rooms are highlighted in red with a warning icon so you
-can easily spot them on the board.
+*agility* dice and take the highest result. Add your hero's agility stat to this roll. If the total meets or exceeds the trap's listed difficulty the trap is disarmed and you receive a random treasure. Failure keeps the trap active and deals damage, so decide carefully. Unresolved trap rooms are highlighted in red with a warning icon so you can easily spot them on the board.
 
 ### Customizing Hero Stats
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -330,7 +330,7 @@ function App() {
       if (!trap) return prev
       const newBoard = board.map(row => row.map(tile => ({ ...tile })))
       const tile = newBoard[trap.position.row][trap.position.col]
-      tile.trapResolved = true
+      tile.trapResolved = success
       let newHero = { ...hero }
       let discard = null
       if (success) {

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -15,7 +15,7 @@ function RoomTile({ tile, onClick, highlight }) {
         tile.revealed
           ? tile.roomId +
             (tile.trap && !tile.trapResolved
-              ? ` - ${DISARM_RULE} Need ${tile.trap.difficulty} points.`
+              ? ` - ${DISARM_RULE} Difficulty ${tile.trap.difficulty}.`
               : '')
           : undefined
       }
@@ -40,7 +40,7 @@ function RoomTile({ tile, onClick, highlight }) {
           title={
             tile.trapResolved
               ? 'Trap disarmed'
-              : `${DISARM_RULE} Need ${tile.trap.difficulty} points.`
+              : `${DISARM_RULE} Difficulty ${tile.trap.difficulty}.`
           }
         >
           {tile.trapResolved ? '✅' : tile.trap.icon}

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -13,9 +13,10 @@ function RoomTile({ tile, onClick, highlight }) {
       onClick={onClick}
       title={
         tile.revealed
-          ? `${tile.roomId}${
-              tile.trap && !tile.trapResolved ? ' - ' + DISARM_RULE : ''
-            }`
+          ? tile.roomId +
+            (tile.trap && !tile.trapResolved
+              ? ` - ${DISARM_RULE} Need ${tile.trap.difficulty} points.`
+              : '')
           : undefined
       }
     >
@@ -33,8 +34,17 @@ function RoomTile({ tile, onClick, highlight }) {
       {tile.revealed && tile.goblin && (
         <span className="goblin-icon">{tile.goblin.icon}</span>
       )}
-      {tile.revealed && tile.trap && !tile.trapResolved && (
-        <span className="trap-icon" title={DISARM_RULE}>⚠️</span>
+      {tile.revealed && tile.trap && (
+        <span
+          className="trap-icon"
+          title={
+            tile.trapResolved
+              ? 'Trap disarmed'
+              : `${DISARM_RULE} Need ${tile.trap.difficulty} points.`
+          }
+        >
+          {tile.trapResolved ? '✅' : tile.trap.icon}
+        </span>
       )}
       {tile.revealed && <span className="room-name">{tile.roomId}</span>}
     </div>

--- a/frontend/src/components/TrapModal.jsx
+++ b/frontend/src/components/TrapModal.jsx
@@ -9,8 +9,8 @@ function TrapModal({ hero, trap, onResolve }) {
   const attempt = () => {
     const r = Array.from({ length: hero.agilityDice }, () => Math.ceil(Math.random() * 6))
     setRolls(r)
-    const points = r.filter(v => v >= 4).length
-    setSuccess(points >= trap.difficulty)
+    const best = Math.max(...r)
+    setSuccess(best + hero.agility >= trap.difficulty)
   }
 
   const close = () => {
@@ -24,7 +24,7 @@ function TrapModal({ hero, trap, onResolve }) {
         {rolls.length === 0 && (
           <>
             <p className="trap-info">
-              {DISARM_RULE} Need {trap.difficulty} points.
+              {DISARM_RULE} Difficulty {trap.difficulty}.
             </p>
             <div className="buttons">
               <button onClick={attempt}>Disarm</button>

--- a/frontend/src/components/TrapModal.jsx
+++ b/frontend/src/components/TrapModal.jsx
@@ -2,14 +2,15 @@ import React, { useState } from 'react'
 import './EncounterModal.css'
 import { DISARM_RULE } from '../trapRules'
 
-function TrapModal({ hero, onResolve }) {
+function TrapModal({ hero, trap, onResolve }) {
   const [rolls, setRolls] = useState([])
   const [success, setSuccess] = useState(null)
 
   const attempt = () => {
     const r = Array.from({ length: hero.agilityDice }, () => Math.ceil(Math.random() * 6))
     setRolls(r)
-    setSuccess(r.some(v => v >= 4))
+    const points = r.filter(v => v >= 4).length
+    setSuccess(points >= trap.difficulty)
   }
 
   const close = () => {
@@ -22,7 +23,9 @@ function TrapModal({ hero, onResolve }) {
         <h2>Trap!</h2>
         {rolls.length === 0 && (
           <>
-            <p className="trap-info">{DISARM_RULE}</p>
+            <p className="trap-info">
+              {DISARM_RULE} Need {trap.difficulty} points.
+            </p>
             <div className="buttons">
               <button onClick={attempt}>Disarm</button>
             </div>

--- a/frontend/src/roomDeck.js
+++ b/frontend/src/roomDeck.js
@@ -30,16 +30,16 @@ GOBLIN_ROOMS.push({
 })
 
 const TRAP_ROOMS = [
-  { roomId: 'Snare Pit', paths: BASE_PATHS[0], trap: true },
-  { roomId: 'Spike Hall', paths: BASE_PATHS[1], trap: true },
-  { roomId: 'Arrow Corridor', paths: BASE_PATHS[2], trap: true },
-  { roomId: 'Flame Trap Room', paths: BASE_PATHS[3], trap: true },
-  { roomId: 'Falling Rock Room', paths: BASE_PATHS[4], trap: true },
-  { roomId: 'Gas Chamber', paths: BASE_PATHS[0], trap: true },
-  { roomId: 'Blade Passage', paths: BASE_PATHS[1], trap: true },
-  { roomId: 'Magic Rune Trap', paths: BASE_PATHS[2], trap: true },
-  { roomId: 'Pendulum Hall', paths: BASE_PATHS[3], trap: true },
-  { roomId: 'Collapsing Floor', paths: BASE_PATHS[4], trap: true },
+  { roomId: 'Snare Pit', paths: BASE_PATHS[0], trap: 'snare' },
+  { roomId: 'Spike Hall', paths: BASE_PATHS[1], trap: 'spikes' },
+  { roomId: 'Arrow Corridor', paths: BASE_PATHS[2], trap: 'spikes' },
+  { roomId: 'Flame Trap Room', paths: BASE_PATHS[3], trap: 'flames' },
+  { roomId: 'Falling Rock Room', paths: BASE_PATHS[4], trap: 'flames' },
+  { roomId: 'Gas Chamber', paths: BASE_PATHS[0], trap: 'runes' },
+  { roomId: 'Blade Passage', paths: BASE_PATHS[1], trap: 'spikes' },
+  { roomId: 'Magic Rune Trap', paths: BASE_PATHS[2], trap: 'runes' },
+  { roomId: 'Pendulum Hall', paths: BASE_PATHS[3], trap: 'spikes' },
+  { roomId: 'Collapsing Floor', paths: BASE_PATHS[4], trap: 'flames' },
 ]
 
 export const ROOM_DECK = [

--- a/frontend/src/trapRules.js
+++ b/frontend/src/trapRules.js
@@ -1,1 +1,29 @@
-export const DISARM_RULE = "Roll your hero's agility dice. Any die that shows 4 or more disarms the trap.";
+export const DISARM_RULE =
+  "Roll your hero's agility dice. Each die of 4 or more counts as one disarm point.";
+
+export const TRAP_TYPES = {
+  snare: {
+    icon: '🪤',
+    difficulty: 1,
+    reward: 1,
+    damage: 1,
+  },
+  spikes: {
+    icon: '☠️',
+    difficulty: 2,
+    reward: 2,
+    damage: 2,
+  },
+  flames: {
+    icon: '🔥',
+    difficulty: 3,
+    reward: 3,
+    damage: 3,
+  },
+  runes: {
+    icon: '✨',
+    difficulty: 4,
+    reward: 4,
+    damage: 4,
+  },
+}

--- a/frontend/src/trapRules.js
+++ b/frontend/src/trapRules.js
@@ -1,28 +1,28 @@
 export const DISARM_RULE =
-  "Roll your hero's agility dice. Each die of 4 or more counts as one disarm point.";
+  "Roll your hero's agility dice. Take the highest roll and add your agility stat. If the total meets or exceeds the trap difficulty, it is disarmed.";
 
 export const TRAP_TYPES = {
   snare: {
     icon: '🪤',
-    difficulty: 1,
+    difficulty: 6,
     reward: 1,
     damage: 1,
   },
   spikes: {
     icon: '☠️',
-    difficulty: 2,
+    difficulty: 7,
     reward: 2,
     damage: 2,
   },
   flames: {
     icon: '🔥',
-    difficulty: 3,
+    difficulty: 8,
     reward: 3,
     damage: 3,
   },
   runes: {
     icon: '✨',
-    difficulty: 4,
+    difficulty: 9,
     reward: 4,
     damage: 4,
   },


### PR DESCRIPTION
## Summary
- create structured trap types with difficulty, reward and damage values
- link trap type info to room deck
- display active and disarmed trap icons on tiles
- show trap difficulty and resolve success based on points rolled
- reward hero with HP on success or apply damage on failure

## Testing
- `npm run lint --prefix frontend`
- `npm run build --prefix frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844f41b55a083268f75dbe4bb97a79d