### PR TITLE
Show treasure reward before discarding

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import EncounterModal from './components/EncounterModal'
 import TrapModal from './components/TrapModal'
 import { TRAP_TYPES } from './trapRules'
 import DiscardModal from './components/DiscardModal'
+import RewardModal from './components/RewardModal'
 import { createShuffledDeck } from './roomDeck'
 import './App.css'
 import { HERO_TYPES } from './heroData'
@@ -100,6 +101,7 @@ function loadState() {
       parsed.encounter = null
       if (!parsed.trap) parsed.trap = null
       if (!parsed.discard) parsed.discard = null
+      if (!parsed.reward) parsed.reward = null
       return parsed
     } catch {
       /* ignore corrupted save */
@@ -121,6 +123,7 @@ function loadState() {
     encounter: null,
     trap: null,
     discard: null,
+    reward: null,
   }
 }
 
@@ -286,18 +289,17 @@ function App() {
       let newEncounter = { ...encounter, goblin: result.goblin }
       let newHero = result.hero
       let discard = prev.discard
+      let reward = prev.reward
       tile.goblin = result.goblin
       if (result.goblin.hp <= 0) {
         tile.goblin = null
         newEncounter = null
         const item = adaptTreasureItem(randomTreasure())
         newHero = { ...newHero, weapons: [...newHero.weapons, item] }
+        reward = item
         discard = null
-        if (newHero.weapons.length > 2) {
-          discard = { items: newHero.weapons }
-        }
       }
-      return { ...prev, board: newBoard, hero: newHero, encounter: newEncounter, discard }
+      return { ...prev, board: newBoard, hero: newHero, encounter: newEncounter, reward, discard }
     })
   }, [])
 
@@ -333,18 +335,28 @@ function App() {
       tile.trapResolved = success
       let newHero = { ...hero }
       let discard = null
+      let reward = prev.reward
       if (success) {
         const item = adaptTreasureItem(randomTreasure())
         newHero.weapons = [...hero.weapons, item]
         newHero.hp = hero.hp + tile.trap.reward
-        if (newHero.weapons.length > 2) {
-          discard = { items: newHero.weapons }
-        }
+        reward = item
       }
       if (!success) {
         newHero.hp = hero.hp - tile.trap.damage
       }
-      return { ...prev, board: newBoard, hero: newHero, trap: null, discard }
+      return { ...prev, board: newBoard, hero: newHero, trap: null, reward, discard }
+    })
+  }, [])
+
+  const handleRewardConfirm = useCallback(() => {
+    setState(prev => {
+      if (!prev.reward) return prev
+      let discard = null
+      if (prev.hero.weapons.length > 2) {
+        discard = { items: prev.hero.weapons }
+      }
+      return { ...prev, reward: null, discard }
     })
   }, [])
 
@@ -355,7 +367,7 @@ function App() {
   useEffect(() => {
     if (!state.hero) return
     const handler = e => {
-      if (state.encounter || state.trap || state.discard) return
+      if (state.encounter || state.trap || state.discard || state.reward) return
       const { row, col } = state.hero
       if (e.key === 'ArrowUp') moveHero(row - 1, col)
       if (e.key === 'ArrowDown') moveHero(row + 1, col)
@@ -364,7 +376,7 @@ function App() {
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [state.hero, state.encounter, moveHero])
+  }, [state.hero, state.encounter, state.trap, state.discard, state.reward, moveHero])
 
   if (!state.hero) {
     return <HeroSelect onSelect={chooseHero} />
@@ -415,6 +427,9 @@ function App() {
       )}
       {state.trap && (
         <TrapModal hero={state.hero} trap={state.trap.trap} onResolve={handleTrapResolve} />
+      )}
+      {state.reward && (
+        <RewardModal item={state.reward} onConfirm={handleRewardConfirm} />
       )}
       {state.discard && (
         <DiscardModal items={state.discard.items} onConfirm={handleDiscardConfirm} />

--- a/frontend/src/components/RewardModal.jsx
+++ b/frontend/src/components/RewardModal.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import ItemCard from './ItemCard'
+import './EncounterModal.css'
+
+function RewardModal({ item, onConfirm }) {
+  return (
+    <div className="encounter-overlay">
+      <div className="encounter-window">
+        <h2>New Treasure</h2>
+        <ItemCard item={item} />
+        <div className="buttons">
+          <button onClick={onConfirm}>OK</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RewardModal


### PR DESCRIPTION
## Summary
- add a `RewardModal` component to display newly earned items
- keep reward item in game state and block actions until acknowledged
- render `RewardModal` before opening the discard window

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845515cd46c83268eeebc84ce90a721