### PR TITLE
Add monster death effect

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,6 +52,7 @@ function createEmptyBoard() {
       revealed: false,
       paths: { up: false, down: false, left: false, right: false },
       goblin: null,
+      effect: null,
     }))
   )
 }
@@ -71,6 +72,7 @@ function loadState() {
               tile.trap = { ...TRAP_TYPES[tile.trap], id: tile.trap }
             }
             if (!('trapResolved' in tile)) tile.trapResolved = false
+            if (!('effect' in tile)) tile.effect = null
           })
         )
       }
@@ -113,6 +115,7 @@ function loadState() {
     revealed: true,
     paths: { up: true, down: true, left: true, right: true },
     goblin: null,
+    effect: null,
   }
   return {
     board,
@@ -214,6 +217,7 @@ function App() {
           goblin,
           trap: room.trap ? { ...TRAP_TYPES[room.trap], id: room.trap } : null,
           trapResolved: false,
+          effect: null,
         }
       } else if (!target.paths[opposite(dir)]) {
         return
@@ -287,8 +291,11 @@ function App() {
       let newHero = result.hero
       let discard = prev.discard
       tile.goblin = result.goblin
+      const row = encounter.position.row
+      const col = encounter.position.col
       if (result.goblin.hp <= 0) {
         tile.goblin = null
+        tile.effect = 'death'
         newEncounter = null
         const item = adaptTreasureItem(randomTreasure())
         newHero = { ...newHero, weapons: [...newHero.weapons, item] }
@@ -296,6 +303,14 @@ function App() {
         if (newHero.weapons.length > 2) {
           discard = { items: newHero.weapons }
         }
+        setTimeout(() => {
+          setState(p => {
+            const copy = p.board.map(r => r.map(t => ({ ...t })))
+            const t = copy[row][col]
+            if (t.effect === 'death') t.effect = null
+            return { ...p, board: copy }
+          })
+        }, 600)
       }
       return { ...prev, board: newBoard, hero: newHero, encounter: newEncounter, discard }
     })

--- a/frontend/src/components/EncounterModal.css
+++ b/frontend/src/components/EncounterModal.css
@@ -17,6 +17,31 @@
   text-align: center;
 }
 
+.goblin-image {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  margin: 0 auto;
+}
+
+.death-effect {
+  position: absolute;
+  inset: 10%;
+  pointer-events: none;
+  animation: fade-out 0.6s forwards;
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1.2);
+  }
+}
+
 .encounter-window .stats {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/frontend/src/components/EncounterModal.css
+++ b/frontend/src/components/EncounterModal.css
@@ -142,3 +142,57 @@
 .shake {
   animation: shake 0.3s;
 }
+
+.reward-info {
+  margin-bottom: 0.5rem;
+}
+
+.reward-card {
+  perspective: 600px;
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 0.5rem;
+  cursor: pointer;
+}
+
+.reward-inner {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.6s;
+}
+
+.reward-card.revealed .reward-inner {
+  transform: rotateY(180deg);
+}
+
+.reward-face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backface-visibility: hidden;
+}
+
+.reward-face.back {
+  transform: rotateY(180deg);
+}
+
+.card-back {
+  background-color: #333;
+  border: 1px solid #999;
+  border-radius: 4px;
+  width: 80px;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-back img {
+  width: 40px;
+  height: 40px;
+}

--- a/frontend/src/components/EncounterModal.jsx
+++ b/frontend/src/components/EncounterModal.jsx
@@ -63,20 +63,28 @@ function EncounterModal({ goblin, hero, onFight, onFlee }) {
     <div className="encounter-overlay">
       <div className="encounter-window">
         <h2>{goblin.name}</h2>
-        <img
-          src={goblin.image}
-          alt={goblin.name}
-          width="100"
-          height="100"
-          className={
-            stage === 'result' &&
+        <div className="goblin-image">
+          <img
+            src={goblin.image}
+            alt={goblin.name}
+            width="100"
+            height="100"
+            className={
+              stage === 'result' &&
+              result &&
+              result.type === 'fight' &&
+              result.heroDmg > 0
+                ? 'shake'
+                : undefined
+            }
+          />
+          {stage === 'result' &&
             result &&
             result.type === 'fight' &&
-            result.heroDmg > 0
-              ? 'shake'
-              : undefined
-          }
-        />
+            result.goblin.hp <= 0 && (
+              <img src="/star.svg" alt="defeated" className="death-effect" />
+            )}
+        </div>
         <div className="stats">
           <div className="label">HP</div>
           <div>{goblin.hp}</div>

--- a/frontend/src/components/RewardModal.jsx
+++ b/frontend/src/components/RewardModal.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import ItemCard from './ItemCard'
+import './EncounterModal.css'
+
+function RewardModal({ reward, onConfirm }) {
+  const [revealed, setRevealed] = useState(false)
+  return (
+    <div className="encounter-overlay">
+      <div className="encounter-window">
+        <h2>You got a reward!</h2>
+        <p className="reward-info">
+          1 random item{reward.hp ? ` and ${reward.hp} hp` : ''}
+        </p>
+        <div
+          className={`reward-card ${revealed ? 'revealed' : ''}`}
+          onClick={() => setRevealed(true)}
+        >
+          <div className="reward-inner">
+            <div className="reward-face front">
+              <div className="card-back">
+                <img src="/star.svg" alt="Card back" />
+              </div>
+            </div>
+            <div className="reward-face back">
+              <ItemCard item={reward.item} />
+            </div>
+          </div>
+        </div>
+        <div className="buttons">
+          {revealed ? (
+            <button onClick={onConfirm}>OK</button>
+          ) : (
+            <button onClick={() => setRevealed(true)}>Reveal</button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RewardModal

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -116,6 +116,24 @@
   font-size: 0.7rem;
 }
 
+.death-effect {
+  position: absolute;
+  inset: 10%;
+  pointer-events: none;
+  animation: fade-out 0.6s forwards;
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1.2);
+  }
+}
+
 .room-name {
   position: absolute;
   top: 50%;

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -34,6 +34,9 @@ function RoomTile({ tile, onClick, highlight }) {
       {tile.revealed && tile.goblin && (
         <span className="goblin-icon">{tile.goblin.icon}</span>
       )}
+      {tile.revealed && tile.effect === 'death' && (
+        <img src="/star.svg" alt="defeated" className="death-effect" />
+      )}
       {tile.revealed && tile.trap && (
         <span
           className="trap-icon"


### PR DESCRIPTION
## Summary
- show star animation when monsters die
- store transient tile effects in game state

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455147417c832680ba3e9451a6d79e