### PR TITLE
Add hero damage effect

### DIFF
--- a/frontend/src/components/Hero.css
+++ b/frontend/src/components/Hero.css
@@ -8,3 +8,25 @@
   align-items: center;
   border-radius: 4px;
 }
+
+@keyframes shake {
+  0% {
+    transform: translate(0);
+  }
+  25% {
+    transform: translate(-3px);
+  }
+  50% {
+    transform: translate(3px);
+  }
+  75% {
+    transform: translate(-3px);
+  }
+  100% {
+    transform: translate(0);
+  }
+}
+
+.shake {
+  animation: shake 0.3s;
+}

--- a/frontend/src/components/Hero.jsx
+++ b/frontend/src/components/Hero.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import './Hero.css'
 
-function Hero({ hero }) {
-  return <div className="hero">{hero.icon}</div>
+function Hero({ hero, damaged }) {
+  return <div className={`hero${damaged ? ' shake' : ''}`}>{hero.icon}</div>
 }
 
 export default Hero

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import './HeroPanel.css'
 import ItemCard from './ItemCard'
 
-function HeroPanel({ hero }) {
+function HeroPanel({ hero, damaged }) {
   return (
     <div className="hero-panel">
       <h2>Hero</h2>
@@ -11,6 +11,7 @@ function HeroPanel({ hero }) {
         alt={hero.name}
         width="100"
         height="100"
+        className={damaged ? 'shake' : undefined}
         style={{ display: 'block', margin: '0 auto 8px' }}
       />
       <div className="stats">


### PR DESCRIPTION
## Summary
- add heroDamaged state to detect health loss
- shake hero icon when damaged
- propagate damage effect to hero panel portrait

## Testing
- `npm run lint --prefix frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455169bb78832698a0dd8754d0eca7