### PR TITLE
Improve hero panel into card

### DIFF
--- a/frontend/src/components/HeroPanel.css
+++ b/frontend/src/components/HeroPanel.css
@@ -1,4 +1,12 @@
 .hero-panel {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.hero-card {
   background-color: #d8c47d;
   color: #1a1a1a;
   padding: 8px;
@@ -43,7 +51,6 @@
 .weapons {
   display: flex;
   gap: 0.5rem;
-  margin-top: 0.5rem;
 }
 
 .icons {

--- a/frontend/src/components/HeroPanel.css
+++ b/frontend/src/components/HeroPanel.css
@@ -7,13 +7,13 @@
 }
 
 .hero-card {
-  background-color: #d8c47d;
-  color: #1a1a1a;
+  background-color: #f5ecd9;
+  color: #111;
   padding: 8px;
-  width: min(200px, 35vmin);
-  border-radius: 6px;
-  border: 2px solid #333;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  width: min(220px, 40vmin);
+  border-radius: 8px;
+  border: 4px solid #000;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.6);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -22,8 +22,9 @@
 
 .card-title {
   font-weight: bold;
-  font-size: 1.1em;
+  font-size: 1.2em;
   margin-bottom: 4px;
+  text-align: center;
 }
 
 .hero-image {
@@ -48,18 +49,11 @@
 }
 
 
+.value {
+  font-weight: bold;
+}
+
 .weapons {
   display: flex;
   gap: 0.5rem;
-}
-
-.icons {
-  display: flex;
-  gap: 2px;
-  align-items: center;
-}
-
-.stat-icon {
-  width: 12px;
-  height: 12px;
 }

--- a/frontend/src/components/HeroPanel.css
+++ b/frontend/src/components/HeroPanel.css
@@ -1,17 +1,28 @@
 .hero-panel {
-  background-color: #444;
-  color: white;
+  background-color: #d8c47d;
+  color: #1a1a1a;
   padding: 8px;
-  width: min(180px, 30vmin);
-  border-radius: 4px;
+  width: min(200px, 35vmin);
+  border-radius: 6px;
+  border: 2px solid #333;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
   display: flex;
   flex-direction: column;
   align-items: center;
+  font-family: 'Times New Roman', serif;
 }
 
-.hero-panel h2 {
-  margin: 0 0 4px;
-  font-size: 1em;
+.card-title {
+  font-weight: bold;
+  font-size: 1.1em;
+  margin-bottom: 4px;
+}
+
+.hero-image {
+  display: block;
+  margin: 0 auto 8px;
+  border: 1px solid #333;
+  border-radius: 4px;
 }
 
 .stats {

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -5,68 +5,70 @@ import ItemCard from './ItemCard'
 function HeroPanel({ hero, damaged }) {
   return (
     <div className="hero-panel">
-      <div className="card-title">{hero.name}</div>
-      <img
-        src={hero.image}
-        alt={hero.name}
-        width="100"
-        height="100"
-        className={damaged ? 'hero-image shake' : 'hero-image'}
-      />
-      <div className="stats">
-        <div className="label">Move</div>
-        <div className="icons">
-          {Array.from({ length: hero.movement }, (_, i) => (
-            <img key={i} src="/boot.svg" alt="move" className="stat-icon" />
-          ))}
-        </div>
-        <div className="label">HP</div>
-        <div className="icons">
-          {Array.from({ length: hero.hp }, (_, i) => (
-            <img key={i} src="/heart.svg" alt="hp" className="stat-icon" />
-          ))}
-        </div>
-        <div className="label">AP</div>
-        <div className="icons">
-          {Array.from({ length: hero.ap }, (_, i) => (
-            <img key={i} src="/star.svg" alt="ap" className="stat-icon" />
-          ))}
-        </div>
-        <div className="label">STR</div>
-        <div className="icons">
-          {Array.from({ length: hero.attack }, (_, i) => (
-            <img key={i} src="/fist.svg" alt="strength" className="stat-icon" />
-          ))}
-        </div>
-        <div className="label">Def</div>
-        <div className="icons">
-          {Array.from({ length: hero.defence }, (_, i) => (
-            <img key={i} src="/shield.svg" alt="defence" className="stat-icon" />
-          ))}
-        </div>
-        <div className="label">Agi</div>
-        <div className="icons">
-          {Array.from({ length: hero.agility }, (_, i) => (
-            <img key={i} src="/wing.svg" alt="agility" className="stat-icon" />
-          ))}
-        </div>
-        <div className="label">STR Dice</div>
-        <div className="icons">
-          {Array.from({ length: hero.strengthDice }, (_, i) => (
-            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-          ))}
-        </div>
-        <div className="label">Agi Dice</div>
-        <div className="icons">
-          {Array.from({ length: hero.agilityDice }, (_, i) => (
-            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-          ))}
-        </div>
-        <div className="label">Magic Dice</div>
-        <div className="icons">
-          {Array.from({ length: hero.magicDice }, (_, i) => (
-            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-          ))}
+      <div className="hero-card">
+        <div className="card-title">{hero.name}</div>
+        <img
+          src={hero.image}
+          alt={hero.name}
+          width="100"
+          height="100"
+          className={damaged ? 'hero-image shake' : 'hero-image'}
+        />
+        <div className="stats">
+          <div className="label">Move</div>
+          <div className="icons">
+            {Array.from({ length: hero.movement }, (_, i) => (
+              <img key={i} src="/boot.svg" alt="move" className="stat-icon" />
+            ))}
+          </div>
+          <div className="label">HP</div>
+          <div className="icons">
+            {Array.from({ length: hero.hp }, (_, i) => (
+              <img key={i} src="/heart.svg" alt="hp" className="stat-icon" />
+            ))}
+          </div>
+          <div className="label">AP</div>
+          <div className="icons">
+            {Array.from({ length: hero.ap }, (_, i) => (
+              <img key={i} src="/star.svg" alt="ap" className="stat-icon" />
+            ))}
+          </div>
+          <div className="label">STR</div>
+          <div className="icons">
+            {Array.from({ length: hero.attack }, (_, i) => (
+              <img key={i} src="/fist.svg" alt="strength" className="stat-icon" />
+            ))}
+          </div>
+          <div className="label">Def</div>
+          <div className="icons">
+            {Array.from({ length: hero.defence }, (_, i) => (
+              <img key={i} src="/shield.svg" alt="defence" className="stat-icon" />
+            ))}
+          </div>
+          <div className="label">Agi</div>
+          <div className="icons">
+            {Array.from({ length: hero.agility }, (_, i) => (
+              <img key={i} src="/wing.svg" alt="agility" className="stat-icon" />
+            ))}
+          </div>
+          <div className="label">STR Dice</div>
+          <div className="icons">
+            {Array.from({ length: hero.strengthDice }, (_, i) => (
+              <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
+            ))}
+          </div>
+          <div className="label">Agi Dice</div>
+          <div className="icons">
+            {Array.from({ length: hero.agilityDice }, (_, i) => (
+              <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
+            ))}
+          </div>
+          <div className="label">Magic Dice</div>
+          <div className="icons">
+            {Array.from({ length: hero.magicDice }, (_, i) => (
+              <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
+            ))}
+          </div>
         </div>
       </div>
       <div className="weapons">

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -16,59 +16,23 @@ function HeroPanel({ hero, damaged }) {
         />
         <div className="stats">
           <div className="label">Move</div>
-          <div className="icons">
-            {Array.from({ length: hero.movement }, (_, i) => (
-              <img key={i} src="/boot.svg" alt="move" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.movement}</div>
           <div className="label">HP</div>
-          <div className="icons">
-            {Array.from({ length: hero.hp }, (_, i) => (
-              <img key={i} src="/heart.svg" alt="hp" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.hp}</div>
           <div className="label">AP</div>
-          <div className="icons">
-            {Array.from({ length: hero.ap }, (_, i) => (
-              <img key={i} src="/star.svg" alt="ap" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.ap}</div>
           <div className="label">STR</div>
-          <div className="icons">
-            {Array.from({ length: hero.attack }, (_, i) => (
-              <img key={i} src="/fist.svg" alt="strength" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.attack}</div>
           <div className="label">Def</div>
-          <div className="icons">
-            {Array.from({ length: hero.defence }, (_, i) => (
-              <img key={i} src="/shield.svg" alt="defence" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.defence}</div>
           <div className="label">Agi</div>
-          <div className="icons">
-            {Array.from({ length: hero.agility }, (_, i) => (
-              <img key={i} src="/wing.svg" alt="agility" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.agility}</div>
           <div className="label">STR Dice</div>
-          <div className="icons">
-            {Array.from({ length: hero.strengthDice }, (_, i) => (
-              <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.strengthDice}</div>
           <div className="label">Agi Dice</div>
-          <div className="icons">
-            {Array.from({ length: hero.agilityDice }, (_, i) => (
-              <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.agilityDice}</div>
           <div className="label">Magic Dice</div>
-          <div className="icons">
-            {Array.from({ length: hero.magicDice }, (_, i) => (
-              <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-            ))}
-          </div>
+          <div className="value">{hero.magicDice}</div>
         </div>
       </div>
       <div className="weapons">

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -5,14 +5,13 @@ import ItemCard from './ItemCard'
 function HeroPanel({ hero, damaged }) {
   return (
     <div className="hero-panel">
-      <h2>Hero</h2>
+      <div className="card-title">{hero.name}</div>
       <img
         src={hero.image}
         alt={hero.name}
         width="100"
         height="100"
-        className={damaged ? 'shake' : undefined}
-        style={{ display: 'block', margin: '0 auto 8px' }}
+        className={damaged ? 'hero-image shake' : 'hero-image'}
       />
       <div className="stats">
         <div className="label">Move</div>


### PR DESCRIPTION
## Summary
- redesign hero panel to look like a card
- show hero name as card title
- adjust styles for card look

## Testing
- `npm --workspaces=false --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846854fb94083268b8f78000f33e65a