### PR TITLE
Add Viking hero and new hero panel layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The current version shows a hero portrait drawn in a Hearthstone‑style. Each h
 - Dungeon with a 7x7 grid of tiles.
 - 70 prepared room tiles.
 - Open new rooms only when a character moves to a connecting exit.
-- Two characters: knight and elf.
+- Three characters: knight, elf and viking.
 - Choose your hero at the start of the game.
 - Characters have attributes:
   - Movement range

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -41,6 +41,13 @@
   gap: 0.5rem;
 }
 
+.hero-items {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 .end-turn {
   width: 100%;
 }
@@ -68,6 +75,10 @@
   }
   .hero-panel {
     width: 100%;
+  }
+  .hero-items {
+    width: 100%;
+    justify-content: center;
   }
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
 import RoomTile from './components/RoomTile'
 import Hero from './components/Hero'
 import HeroPanel from './components/HeroPanel'
+import ItemCard from './components/ItemCard'
 import HeroSelect from './components/HeroSelect'
 import EncounterModal from './components/EncounterModal'
 import TrapModal from './components/TrapModal'
@@ -83,6 +84,7 @@ function loadState() {
         parsed.hero = {
           row: parsed.hero.row,
           col: parsed.hero.col,
+          skill: parsed.hero.skill ?? base.skill,
           movement: parsed.hero.movement ?? base.movement,
           icon: parsed.hero.icon ?? base.icon,
           hp: parsed.hero.hp ?? base.hp,
@@ -141,6 +143,7 @@ function App() {
       row: CENTER,
       col: CENTER,
       name: base.name,
+      skill: base.skill,
       movement: base.movement,
       icon: base.icon,
       hp: base.hp,
@@ -442,6 +445,13 @@ function App() {
         </div>
       <div className="side">
         <HeroPanel hero={state.hero} damaged={heroDamaged} />
+        {state.hero && (
+          <div className="hero-items">
+            {state.hero.weapons.map((w, idx) => (
+              <ItemCard key={idx} item={w} />
+            ))}
+          </div>
+        )}
         <button onClick={endTurn} className="end-turn">End Turn</button>
         <button onClick={resetGame} className="reset-game">Reset Game</button>
       </div>

--- a/frontend/src/components/HeroPanel.css
+++ b/frontend/src/components/HeroPanel.css
@@ -1,47 +1,95 @@
 .hero-panel {
-  background-color: #444;
-  color: white;
-  padding: 8px;
-  width: min(180px, 30vmin);
-  border-radius: 4px;
+  position: relative;
+  width: 180px;
+  height: 260px;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.6);
+  transform: rotate(-3deg);
+}
+
+.name-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.9);
+  color: #000;
+  text-align: center;
+  font-weight: bold;
+  padding: 2px 0;
+  z-index: 2;
+}
+
+.card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.stats-bar {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50px;
+  background: rgba(0, 0, 0, 0.7);
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding-top: 24px;
 }
 
-.hero-panel h2 {
-  margin: 0 0 4px;
-  font-size: 1em;
-}
-
-.stats {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 2px 4px;
-  width: 100%;
-  font-size: 0.75em;
-}
-
-
-.label {
-  text-align: right;
-  opacity: 0.8;
-}
-
-
-.weapons {
+.stat {
   display: flex;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-.icons {
-  display: flex;
-  gap: 2px;
+  flex-direction: column;
   align-items: center;
+  color: #fff;
+  font-size: 0.8rem;
 }
 
-.stat-icon {
-  width: 12px;
-  height: 12px;
+.stat img {
+  width: 20px;
+  height: 20px;
+}
+
+.description {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 33%;
+  background: rgba(255, 255, 255, 0.7);
+  color: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4px;
+  font-size: 0.8rem;
+}
+
+@keyframes shake {
+  0% {
+    transform: translate(0);
+  }
+  25% {
+    transform: translate(-3px);
+  }
+  50% {
+    transform: translate(3px);
+  }
+  75% {
+    transform: translate(-3px);
+  }
+  100% {
+    transform: translate(0);
+  }
+}
+
+.shake {
+  animation: shake 0.3s;
 }

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -1,80 +1,52 @@
 import React from 'react'
 import './HeroPanel.css'
-import ItemCard from './ItemCard'
 
 function HeroPanel({ hero, damaged }) {
+  if (!hero) return null
+
   return (
-    <div className="hero-panel">
-      <h2>Hero</h2>
-      <img
-        src={hero.image}
-        alt={hero.name}
-        width="100"
-        height="100"
-        className={damaged ? 'shake' : undefined}
-        style={{ display: 'block', margin: '0 auto 8px' }}
-      />
-      <div className="stats">
-        <div className="label">Move</div>
-        <div className="icons">
-          {Array.from({ length: hero.movement }, (_, i) => (
-            <img key={i} src="/boot.svg" alt="move" className="stat-icon" />
-          ))}
+    <div className={`hero-panel${damaged ? ' shake' : ''}`}>
+      <div className="name-bar">{hero.name}</div>
+      <img className="card-image" src={hero.image} alt={hero.name} />
+      <div className="stats-bar">
+        <div className="stat">
+          <img src="/boot.png" alt="move" />
+          <span>{hero.movement}</span>
         </div>
-        <div className="label">HP</div>
-        <div className="icons">
-          {Array.from({ length: hero.hp }, (_, i) => (
-            <img key={i} src="/heart.svg" alt="hp" className="stat-icon" />
-          ))}
+        <div className="stat">
+          <img src="/heart.png" alt="hp" />
+          <span>{hero.hp}</span>
         </div>
-        <div className="label">AP</div>
-        <div className="icons">
-          {Array.from({ length: hero.ap }, (_, i) => (
-            <img key={i} src="/star.svg" alt="ap" className="stat-icon" />
-          ))}
+        <div className="stat">
+          <img src="/icon/starburst.png" alt="ap" />
+          <span>{hero.ap}</span>
         </div>
-        <div className="label">STR</div>
-        <div className="icons">
-          {Array.from({ length: hero.attack }, (_, i) => (
-            <img key={i} src="/fist.svg" alt="strength" className="stat-icon" />
-          ))}
+        <div className="stat">
+          <img src="/fist.png" alt="strength" />
+          <span>{hero.attack}</span>
         </div>
-        <div className="label">Def</div>
-        <div className="icons">
-          {Array.from({ length: hero.defence }, (_, i) => (
-            <img key={i} src="/shield.svg" alt="defence" className="stat-icon" />
-          ))}
+        <div className="stat">
+          <img src="/shield.png" alt="defence" />
+          <span>{hero.defence}</span>
         </div>
-        <div className="label">Agi</div>
-        <div className="icons">
-          {Array.from({ length: hero.agility }, (_, i) => (
-            <img key={i} src="/wing.svg" alt="agility" className="stat-icon" />
-          ))}
+        <div className="stat">
+          <img src="/speed.png" alt="agility" />
+          <span>{hero.agility}</span>
         </div>
-        <div className="label">STR Dice</div>
-        <div className="icons">
-          {Array.from({ length: hero.strengthDice }, (_, i) => (
-            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-          ))}
+        <div className="stat">
+          <img src="/dice.png" alt="strength dice" />
+          <span>{hero.strengthDice}</span>
         </div>
-        <div className="label">Agi Dice</div>
-        <div className="icons">
-          {Array.from({ length: hero.agilityDice }, (_, i) => (
-            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-          ))}
+        <div className="stat">
+          <img src="/dice.png" alt="agility dice" />
+          <span>{hero.agilityDice}</span>
         </div>
-        <div className="label">Magic Dice</div>
-        <div className="icons">
-          {Array.from({ length: hero.magicDice }, (_, i) => (
-            <img key={i} src="/dice.svg" alt="dice" className="stat-icon" />
-          ))}
+        <div className="stat">
+          <img src="/dice.png" alt="magic dice" />
+          <span>{hero.magicDice}</span>
         </div>
       </div>
-      <div className="weapons">
-        {hero.weapons.map((w, idx) => (
-          <ItemCard key={idx} item={w} />
-        ))}
-      </div>
+      <div className="description">{hero.skill}</div>
     </div>
   )
 }

--- a/frontend/src/heroData.js
+++ b/frontend/src/heroData.js
@@ -1,6 +1,7 @@
 export const HERO_TYPES = {
   knight: {
     name: 'Knight',
+    skill: 'Defensive stance',
     movement: 3,
     hp: 12,
     ap: 2,
@@ -31,6 +32,7 @@ export const HERO_TYPES = {
   },
   elf: {
     name: 'Elf',
+    skill: 'Forest stealth',
     movement: 4,
     hp: 8,
     ap: 3,
@@ -56,6 +58,30 @@ export const HERO_TYPES = {
         defence: 1,
         dice: 'agility',
         image: '/dagger.svg',
+      },
+    ],
+  },
+  viking: {
+    name: 'Viking',
+    skill: 'Berserker rage',
+    movement: 3,
+    hp: 10,
+    ap: 2,
+    attack: 5,
+    defence: 2,
+    agility: 2,
+    strengthDice: 4,
+    agilityDice: 1,
+    magicDice: 0,
+    icon: 'V',
+    image: '/hero-viking.webp',
+    weapons: [
+      {
+        name: 'Axe',
+        attack: 3,
+        defence: 0,
+        dice: 'strength',
+        image: '/sword.png',
       },
     ],
   },


### PR DESCRIPTION
## Summary
- overhaul HeroPanel to look like a tilted card with stats sidebar
- move item cards outside of the hero card
- add Viking hero with unique art and skill
- use PNG icons for hero attributes
- mention Viking in README

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846960f9e608326b9b9057f80500e37