### PR TITLE
Add selectable extra dice for encounters

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -301,12 +301,12 @@ function App() {
     return moves
   }, [state])
 
-  const handleFight = useCallback((rolls, baseIdx, weaponIdx) => {
+  const handleFight = useCallback((rolls, baseIdx, weaponIdx, extraIdxs) => {
     setState(prev => {
       const { encounter, board, hero } = prev
       if (!encounter) return prev
       const weapon = hero.weapons[weaponIdx]
-      const result = fightGoblin(hero, encounter.goblin, weapon, rolls, baseIdx)
+      const result = fightGoblin(hero, encounter.goblin, weapon, rolls, baseIdx, extraIdxs)
       const newBoard = board.map(row => row.map(tile => ({ ...tile })))
       const tile = newBoard[encounter.position.row][encounter.position.col]
       let newEncounter = { ...encounter, goblin: result.goblin }

--- a/frontend/src/components/EncounterModal.css
+++ b/frontend/src/components/EncounterModal.css
@@ -77,8 +77,20 @@
 .dice.base {
   background-color: #883333;
 }
+.dice.extra {
+  background-color: #333888;
+}
+.dice.disabled {
+  opacity: 0.5;
+  cursor: default;
+}
 .dice.selectable:hover {
   background-color: #555;
+}
+.dice .plus-icon {
+  width: 10px;
+  height: 10px;
+  margin-right: 2px;
 }
 
 .info {

--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import './ItemCard.css';
 
-function renderIcons(count, icon, alt) {
-  return Array.from({ length: count }, (_, i) => (
-    <img key={i} src={icon} alt={alt} className="stat-icon" />
-  ));
-}
-
 function ItemCard({ item }) {
   const typeIcons = {
     melee: '/fist.svg',

--- a/frontend/src/fightUtils.js
+++ b/frontend/src/fightUtils.js
@@ -1,28 +1,28 @@
 
-export function computeAttackBreakdown(hero, weapon, rolls, baseIdx) {
+export function computeAttackBreakdown(hero, weapon, rolls, baseIdx, extraIdxs = []) {
   const heroPart = hero.attack
   const weaponPart = weapon.attack
   let base = 0
   let extra = 0
   if (baseIdx != null && rolls[baseIdx] >= 3) {
     base = rolls[baseIdx]
-    rolls.forEach((v, idx) => {
-      if (idx !== baseIdx && v <= 2) extra += v
+    extraIdxs.forEach(idx => {
+      if (idx !== baseIdx && rolls[idx] <= 2) extra += rolls[idx]
     })
   }
   const total = heroPart + weaponPart + base + extra
   return { total, hero: heroPart, weapon: weaponPart, base, extra }
 }
 
-export function computeAttackPower(hero, weapon, rolls, baseIdx) {
-  return computeAttackBreakdown(hero, weapon, rolls, baseIdx).total
+export function computeAttackPower(hero, weapon, rolls, baseIdx, extraIdxs = []) {
+  return computeAttackBreakdown(hero, weapon, rolls, baseIdx, extraIdxs).total
 }
 
-export function fightGoblin(hero, goblin, weapon, rolls, baseIdx) {
+export function fightGoblin(hero, goblin, weapon, rolls, baseIdx, extraIdxs = []) {
   let heroHp = hero.hp
   let goblinHp = goblin.hp
 
-  const details = computeAttackBreakdown(hero, weapon, rolls, baseIdx)
+  const details = computeAttackBreakdown(hero, weapon, rolls, baseIdx, extraIdxs)
   const attackPower = details.total
   const heroDefence = hero.defence + weapon.defence
   const heroDmg = Math.max(1, attackPower - goblin.defence)


### PR DESCRIPTION
## Summary
- allow picking low dice as extra points
- disable low dice until a base die is chosen
- show `+` icon for add-on dice
- update damage calculations for extra dice
- clean up unused helper in `ItemCard`

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6847439f41948326a58c303a9e2efcbe