### PR TITLE
Display hero movement on card

### DIFF
--- a/frontend/src/components/HeroPanel.css
+++ b/frontend/src/components/HeroPanel.css
@@ -111,6 +111,35 @@
   animation: shake 0.3s;
 }
 
+.movement-badge {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  z-index: 3;
+  transform: rotate(-5deg);
+}
+
+.movement-badge img {
+  width: 100%;
+  height: 100%;
+}
+
+.movement-badge span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
 .defence-badge {
   position: absolute;
   bottom: 2%;

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -14,6 +14,10 @@ function HeroPanel({ hero, damaged }) {
     <div className={`hero-panel${damaged ? ' shake' : ''}`}>
       <div className="name-bar">{hero.name}</div>
       <img className="card-image" src={hero.image} alt={hero.name} />
+      <div className="movement-badge">
+        <img src="/icon/footprint.png" alt="movement" />
+        <span>{hero.movement}</span>
+      </div>
       <div className="stats-bar">
         <span className="stat"><img src="/fist.png" alt="strength" />{renderDice(hero.strengthDice, 'strength die')}·</span>
         <span className="stat"><img src="/arrows.png" alt="agility" />{renderDice(hero.agilityDice, 'agility die')}·</span>


### PR DESCRIPTION
## Summary
- show hero movement points on hero card
- style the new movement badge overlay

## Testing
- `npm --prefix frontend run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684755558a7c8326930a7e087c8a8c25