### PR TITLE
Update hero movement display

### DIFF
--- a/frontend/src/components/HeroPanel.css
+++ b/frontend/src/components/HeroPanel.css
@@ -111,17 +111,43 @@
   animation: shake 0.3s;
 }
 
-.movement-icons {
+.movement-display {
   position: absolute;
-  bottom: 4rem;
-  right: 0.25rem;
+  top: 0.25rem;
+  left: 0.25rem;
   z-index: 3;
+  display: flex;
+  align-items: center;
+  font-weight: bold;
 }
 
-.movement-icons img {
-  aspect-ratio: 92 / 134;
+.movement-display .foot-icon {
   width: 1.1rem;
+  height: auto;
+  margin-right: 0.1rem;
   transform: rotate(13deg);
+}
+
+.movement-display .cross-icon {
+  width: 0.9rem;
+  height: auto;
+  margin: 0 0.1rem;
+}
+
+.movement-display.change {
+  animation: pop 0.3s;
+}
+
+@keyframes pop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .defence-badge {

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './HeroPanel.css';
 
 function renderDice(count, alt) {
@@ -8,16 +8,28 @@ function renderDice(count, alt) {
 }
 
 function HeroPanel({ hero, damaged }) {
+  const [movePulse, setMovePulse] = useState(false);
+  const prevMoveRef = useRef(hero?.movement ?? 0);
+
+  useEffect(() => {
+    if (hero && prevMoveRef.current !== hero.movement) {
+      setMovePulse(true);
+      const t = setTimeout(() => setMovePulse(false), 300);
+      prevMoveRef.current = hero.movement;
+      return () => clearTimeout(t);
+    }
+  }, [hero]);
+
   if (!hero) return null;
 
   return (
     <div className={`hero-panel${damaged ? ' shake' : ''}`}>
       <div className="name-bar">{hero.name}</div>
       <img className="card-image" src={hero.image} alt={hero.name} />
-      <div className="movement-icons">
-        {Array.from({ length: hero.movement }, (_, i) => (
-          <img key={i} src="/icon/footprint.png" alt="movement" />
-        ))}
+      <div className={`movement-display${movePulse ? ' change' : ''}`}>
+        <img className="foot-icon" src="/icon/footprint.png" alt="movement" />
+        <img className="cross-icon" src="/icon/cross.png" alt="x" />
+        <span className="move-count">{hero.movement}</span>
       </div>
       <div className="stats-bar">
         <span className="stat"><img src="/fist.png" alt="strength" />{renderDice(hero.strengthDice, 'strength die')}·</span>


### PR DESCRIPTION
## Summary
- show hero movement count at top left of card
- animate movement display when the value changes

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6847b6124e30832687fa5156ed0ff8ab