### PR TITLE
Enhance goblin encounter UI

### DIFF
--- a/frontend/src/components/EncounterModal.jsx
+++ b/frontend/src/components/EncounterModal.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import './EncounterModal.css'
 import ItemCard from './ItemCard'
+import GoblinCard from './GoblinCard'
 import {
   computeAttackBreakdown,
   fightGoblin,
@@ -110,37 +111,21 @@ function EncounterModal({ goblin, hero, onFight, onFlee }) {
     <div className={`encounter-overlay${shake ? ' screen-shake' : ''}`}>
       <div className="encounter-window">
         <div className={`encounter-side goblin-side${entered ? ' enter-left' : ''}`}>
-          <h2>{goblin.name}</h2>
-          <div className="goblin-image">
-            <img
-              src={goblin.image}
-              alt={goblin.name}
-              width="100"
-              height="100"
-              className={
-                stage === 'result' &&
-                result &&
-                result.type === 'fight' &&
-                result.heroDmg > 0
-                  ? 'shake'
-                  : undefined
-              }
-            />
-            {stage === 'result' &&
+          <GoblinCard
+            goblin={result && result.goblin ? result.goblin : goblin}
+            damaged={
+              stage === 'result' &&
               result &&
               result.type === 'fight' &&
-              result.goblin.hp <= 0 && (
-                <img src="/skull.png" alt="defeated" className="death-effect red" />
-              )}
-          </div>
-          <div className="stats">
-            <div className="label">HP</div>
-            <div>{goblin.hp}</div>
-            <div className="label">STR</div>
-            <div>{goblin.attack}</div>
-            <div className="label">Def</div>
-            <div>{goblin.defence}</div>
-          </div>
+              result.heroDmg > 0
+            }
+            defeated={
+              stage === 'result' &&
+              result &&
+              result.type === 'fight' &&
+              result.goblin.hp <= 0
+            }
+          />
         </div>
 
         <div className="encounter-middle">

--- a/frontend/src/components/GoblinCard.css
+++ b/frontend/src/components/GoblinCard.css
@@ -1,0 +1,143 @@
+.goblin-card {
+  position: relative;
+  width: 30vmin;
+  aspect-ratio: 2 / 3;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 0.25rem 0.375rem rgba(0, 0, 0, 0.6);
+  transform: rotate(-2deg);
+  backface-visibility: hidden;
+  border: 0.25rem solid #000;
+  box-sizing: border-box;
+}
+
+.name-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  text-align: left;
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 0 0.5rem;
+  z-index: 2;
+  height: 1.2rem;
+  line-height: 1.2rem;
+}
+
+.card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.stats-bar {
+  position: absolute;
+  display: flex;
+  bottom: 1.2rem;
+  left: 0;
+  width: 100%;
+  background: #eaffe4;
+  text-align: center;
+  font-weight: bold;
+  z-index: 2;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  padding-top: 0.2rem;
+}
+
+.stat img {
+  width: 0.8rem;
+  height: 0.8rem;
+  margin-right: 0.05rem;
+}
+
+.hp-hearts {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  display: flex;
+  gap: 0.125rem;
+  z-index: 2;
+}
+
+.hp-hearts img {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.defence-badge {
+  position: absolute;
+  bottom: 2%;
+  right: -1%;
+  width: 3.25rem;
+  height: 3.25rem;
+  z-index: 3;
+  transform: rotate(5deg);
+}
+
+.defence-badge img {
+  width: 100%;
+  height: 100%;
+}
+
+.defence-badge span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 1.4rem;
+  font-weight: bold;
+}
+
+.monster-icon {
+  position: absolute;
+  top: -0.4rem;
+  right: -0.4rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: #fff;
+  border: 0.25rem solid #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 3;
+}
+
+.monster-icon img {
+  width: 70%;
+  height: 70%;
+}
+
+@keyframes shake {
+  0% {
+    transform: translate(0);
+  }
+  25% {
+    transform: translate(-0.2rem);
+  }
+  50% {
+    transform: translate(0.2rem);
+  }
+  75% {
+    transform: translate(-0.2rem);
+  }
+  100% {
+    transform: translate(0);
+  }
+}
+
+.shake {
+  animation: shake 0.3s;
+}

--- a/frontend/src/components/GoblinCard.jsx
+++ b/frontend/src/components/GoblinCard.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import './GoblinCard.css'
+
+function GoblinCard({ goblin, damaged, defeated }) {
+  return (
+    <div className={`goblin-card${damaged ? ' shake' : ''}`}>
+      <div className="name-bar">{goblin.name}</div>
+      <img className="card-image" src={goblin.image} alt={goblin.name} />
+      {defeated && <img src="/skull.png" alt="defeated" className="death-effect red" />}
+      <div className="hp-hearts">
+        {Array.from({ length: goblin.hp }, (_, i) => (
+          <img key={i} src="/heart.png" alt="hp" />
+        ))}
+      </div>
+      <div className="stats-bar">
+        <span className="stat">
+          <img src="/fist.png" alt="attack" />{goblin.attack}
+        </span>
+      </div>
+      <div className="defence-badge">
+        <img src="/shield.png" alt="defence" />
+        <span>{goblin.defence}</span>
+      </div>
+      <div className="monster-icon">
+        <img src="/icon/icon-goblin.png" alt="goblin" />
+      </div>
+    </div>
+  )
+}
+
+export default GoblinCard


### PR DESCRIPTION
## Summary
- add a reusable `GoblinCard` component with visual styling similar to hero cards
- show the goblin card in `EncounterModal` instead of basic stats

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6847eee2b3c483269304610ac9761455