### PR TITLE
Update room tiles visuals

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -441,11 +441,13 @@ function App() {
           {state.board.map((row, rIdx) =>
             row.map((tile, cIdx) => {
               const highlight = possibleMoves.some(p => p.row === rIdx && p.col === cIdx)
+              const disabled = !highlight && (state.hero.row !== rIdx || state.hero.col !== cIdx)
               return (
                 <RoomTile
                   key={`${rIdx}-${cIdx}`}
                   tile={tile}
                   highlight={highlight}
+                  disabled={disabled}
                   onClick={() => moveHero(rIdx, cIdx)}
                 />
               )

--- a/frontend/src/components/RoomTile.css
+++ b/frontend/src/components/RoomTile.css
@@ -17,6 +17,10 @@
   box-shadow: inset 0 0 0 2px yellow;
   cursor: pointer;
 }
+.tile.disabled {
+  opacity: 0.5;
+  cursor: default;
+}
 .tile.revealed {
   background-color: #555;
   border-color: #aaa;
@@ -52,13 +56,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background-image: repeating-linear-gradient(
-    45deg,
-    #222,
-    #222 10px,
-    #333 10px,
-    #333 20px
-  );
+  background-image: url('/cover.png');
+  background-size: cover;
+  background-position: center;
 }
 
 .center {

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -4,12 +4,12 @@ import { DISARM_RULE } from '../trapRules'
 
 const DIRS = ['up', 'down', 'left', 'right']
 
-function RoomTile({ tile, onClick, highlight }) {
+function RoomTile({ tile, onClick, highlight, disabled }) {
   return (
     <div
       className={`tile ${tile.revealed ? 'revealed' : ''} ${highlight ? 'possible' : ''} ${
-        tile.revealed && tile.trap && !tile.trapResolved ? 'trap-room' : ''
-      }`}
+        disabled ? 'disabled' : ''
+      } ${tile.revealed && tile.trap && !tile.trapResolved ? 'trap-room' : ''}`}
       onClick={onClick}
       title={
         tile.revealed


### PR DESCRIPTION
## Summary
- show **cover.png** on back side of room tiles
- gray out unreachable tiles

## Testing
- `npm test`
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847f8424b088326a68115e9c665089c