### PR TITLE
Add counterattack and attack slide effect

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -350,6 +350,9 @@ function App() {
             return { ...p, board: copy }
           })
         }, 600)
+      } else if (result.counter) {
+        // end encounter after counterattack
+        newEncounter = null
       }
       return { ...prev, board: newBoard, hero: newHero, encounter: newEncounter, reward, discard }
     })

--- a/frontend/src/components/EncounterModal.css
+++ b/frontend/src/components/EncounterModal.css
@@ -39,7 +39,7 @@
   padding: 1rem;
   border-radius: 4px;
   width: 100%;
-  height: 80%;
+  height: 85%;
   box-sizing: border-box;
   display: flex;
   align-items: center;
@@ -53,21 +53,34 @@
   margin: 0 auto;
 }
 
+.goblin-card .card-image.defeated {
+  filter: brightness(0.3);
+}
+
 .death-effect {
   position: absolute;
+  width: 120%;
   inset: 10%;
   pointer-events: none;
   animation: fade-out 0.6s forwards;
 }
 
 @keyframes fade-out {
-  from {
+  0% {
     opacity: 1;
-    transform: scale(0.5);
+    transform: scale(0.5) rotate(0);
   }
-  to {
+  30% {
     opacity: 0;
-    transform: scale(1.2);
+    transform: scale(1.5) rotate(20deg);
+  }
+  70% {
+    opacity: 0;
+    transform: scale(0.3) rotate(2deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1.2) rotate(15deg);
   }
 }
 
@@ -227,8 +240,8 @@
 }
 
 .monster-dice img {
-  width: 60%;
-  height: 60%;
+  width: 100%;
+  height: 100%;
 }
 
 .dice-shake {

--- a/frontend/src/components/EncounterModal.css
+++ b/frontend/src/components/EncounterModal.css
@@ -216,6 +216,29 @@
   animation: shake 0.3s;
 }
 
+.monster-dice {
+  width: 40px;
+  height: 40px;
+  background: url('/dice-red.png') center/contain no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+.monster-dice img {
+  width: 60%;
+  height: 60%;
+}
+
+.dice-shake {
+  animation: shake 0.6s;
+}
+
+.torch-icon {
+  font-size: 1.2rem;
+}
+
 .reward-info {
   margin-bottom: 0.5rem;
 }

--- a/frontend/src/components/EncounterModal.jsx
+++ b/frontend/src/components/EncounterModal.jsx
@@ -51,8 +51,14 @@ function EncounterModal({ goblin, hero, onFight, onFlee }) {
     let t
     if (counterPhase === 'roll') {
       t = setTimeout(() => {
+        const label =
+          result.counter.roll != null
+            ? result.counter.roll
+            : result.counter.effect === 'shieldBreak'
+            ? 'shield break'
+            : 'torch down'
         setCounterPhase('show')
-        setCounterMsg(`Rolled ${result.counter.roll}`)
+        setCounterMsg(`Rolled ${label}`)
       }, 1000)
     } else if (counterPhase === 'show') {
       t = setTimeout(() => {
@@ -290,8 +296,24 @@ function EncounterModal({ goblin, hero, onFight, onFlee }) {
             <div className="result-stage">
               <div className="result-message">{counterMsg}</div>
               <div className="dice-container">
-                <div className="dice">
-                  {counterPhase === 'roll' ? '?' : result.counter.roll}
+                <div
+                  className={`monster-dice${
+                    counterPhase === 'roll' ? ' dice-shake' : ''
+                  }`}
+                >
+                  {counterPhase === 'roll'
+                    ? ''
+                    : result.counter.effect === 'shieldBreak'
+                    ? (
+                        <img src="/shield.png" alt="shield break" />
+                      )
+                    : result.counter.effect === 'torchDown'
+                    ? (
+                        <span className="torch-icon">🔥</span>
+                      )
+                    : (
+                        result.counter.roll
+                      )}
                 </div>
               </div>
             </div>

--- a/frontend/src/components/EncounterModal.jsx
+++ b/frontend/src/components/EncounterModal.jsx
@@ -117,7 +117,7 @@ function EncounterModal({ goblin, hero, onFight, onFlee }) {
               stage === 'result' &&
               result &&
               result.type === 'fight' &&
-              result.heroDmg > 0
+              (result.heroDmg > 0 || (result.counter && result.counter.damage > 0))
             }
             defeated={
               stage === 'result' &&

--- a/frontend/src/components/GoblinCard.css
+++ b/frontend/src/components/GoblinCard.css
@@ -120,24 +120,19 @@
   height: 70%;
 }
 
-@keyframes shake {
+
+@keyframes attack-slide {
   0% {
-    transform: translate(0);
-  }
-  25% {
-    transform: translate(-0.2rem);
+    transform: rotate(-2deg) translateX(0);
   }
   50% {
-    transform: translate(0.2rem);
-  }
-  75% {
-    transform: translate(-0.2rem);
+    transform: rotate(-2deg) translateX(1rem);
   }
   100% {
-    transform: translate(0);
+    transform: rotate(-2deg) translateX(0);
   }
 }
 
-.shake {
-  animation: shake 0.3s;
+.attack-slide {
+  animation: attack-slide 0.3s;
 }

--- a/frontend/src/components/GoblinCard.css
+++ b/frontend/src/components/GoblinCard.css
@@ -116,8 +116,8 @@
 }
 
 .monster-icon img {
-  width: 70%;
-  height: 70%;
+  width: 100%;
+  height: 100%;
 }
 
 

--- a/frontend/src/components/GoblinCard.jsx
+++ b/frontend/src/components/GoblinCard.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import './GoblinCard.css'
+import React from 'react';
+import './GoblinCard.css';
 
 function GoblinCard({ goblin, damaged, defeated }) {
   return (
     <div className={`goblin-card${damaged ? ' attack-slide' : ''}`}>
       <div className="name-bar">{goblin.name}</div>
-      <img className="card-image" src={goblin.image} alt={goblin.name} />
+      <img className={`card-image${defeated ? ' defeated' : ''}`} src={goblin.image} alt={goblin.name} />
       {defeated && <img src="/skull.png" alt="defeated" className="death-effect red" />}
       <div className="hp-hearts">
         {Array.from({ length: goblin.hp }, (_, i) => (
@@ -25,7 +25,7 @@ function GoblinCard({ goblin, damaged, defeated }) {
         <img src="/icon/icon-goblin.png" alt="goblin" />
       </div>
     </div>
-  )
+  );
 }
 
-export default GoblinCard
+export default GoblinCard;

--- a/frontend/src/components/GoblinCard.jsx
+++ b/frontend/src/components/GoblinCard.jsx
@@ -3,7 +3,7 @@ import './GoblinCard.css'
 
 function GoblinCard({ goblin, damaged, defeated }) {
   return (
-    <div className={`goblin-card${damaged ? ' shake' : ''}`}>
+    <div className={`goblin-card${damaged ? ' attack-slide' : ''}`}>
       <div className="name-bar">{goblin.name}</div>
       <img className="card-image" src={goblin.image} alt={goblin.name} />
       {defeated && <img src="/skull.png" alt="defeated" className="death-effect red" />}

--- a/frontend/src/fightUtils.js
+++ b/frontend/src/fightUtils.js
@@ -63,20 +63,44 @@ export function fightGoblin(hero, goblin, weapon, rolls, baseIdx, extraIdxs = []
   if (goblinHp > 0) {
     heroHp -= goblinDmg
     message += ` Goblin strikes back for ${goblinDmg}.`
+    const counterRoll = Math.floor(Math.random() * 4) + 2
+    let counter = { roll: counterRoll, effect: null, damage: 0 }
+    if (counterRoll === 5) {
+      counter.effect = 'torchDown'
+      message += ' Counter roll 5 - torch down.'
+    } else {
+      counter.effect = 'shieldBreak'
+      counter.damage = goblin.attack
+      heroHp -= goblin.attack
+      message += ` Counter roll ${counterRoll} - shield break deals ${goblin.attack} damage.`
+    }
+    if (heroHp <= 0) {
+      message += ' You have fallen.'
+    }
+    return {
+      hero: { ...hero, hp: heroHp },
+      goblin: { ...goblin, hp: goblinHp },
+      details,
+      attackPower,
+      heroDmg,
+      goblinDmg,
+      counter,
+      message,
+    }
   } else {
     message += ' Goblin defeated!'
-  }
-  if (heroHp <= 0) {
-    message += ' You have fallen.'
-  }
-
-  return {
-    hero: { ...hero, hp: heroHp },
-    goblin: { ...goblin, hp: goblinHp },
-    details,
-    attackPower,
-    heroDmg,
-    goblinDmg: goblinHp > 0 ? goblinDmg : 0,
-    message,
+    if (heroHp <= 0) {
+      message += ' You have fallen.'
+    }
+    return {
+      hero: { ...hero, hp: heroHp },
+      goblin: { ...goblin, hp: goblinHp },
+      details,
+      attackPower,
+      heroDmg,
+      goblinDmg: 0,
+      counter: null,
+      message,
+    }
   }
 }

--- a/frontend/src/fightUtils.js
+++ b/frontend/src/fightUtils.js
@@ -63,16 +63,19 @@ export function fightGoblin(hero, goblin, weapon, rolls, baseIdx, extraIdxs = []
   if (goblinHp > 0) {
     heroHp -= goblinDmg
     message += ` Goblin strikes back for ${goblinDmg}.`
-    const counterRoll = Math.floor(Math.random() * 4) + 2
-    let counter = { roll: counterRoll, effect: null, damage: 0 }
-    if (counterRoll === 5) {
-      counter.effect = 'torchDown'
-      message += ' Counter roll 5 - torch down.'
-    } else {
-      counter.effect = 'shieldBreak'
-      counter.damage = goblin.attack
-      heroHp -= goblin.attack
-      message += ` Counter roll ${counterRoll} - shield break deals ${goblin.attack} damage.`
+    let counter = null
+    if (heroHp > 0) {
+      const faces = ['torchDown', 2, 3, 4, 5, 'shieldBreak']
+      const face = faces[Math.floor(Math.random() * faces.length)]
+      counter = {
+        roll: typeof face === 'number' ? face : null,
+        effect: face === 'shieldBreak' || face === 'torchDown' ? face : null,
+        damage: 0,
+      }
+      if (face === 'shieldBreak') {
+        counter.damage = goblin.attack
+        heroHp -= goblin.attack
+      }
     }
     if (heroHp <= 0) {
       message += ' You have fallen.'


### PR DESCRIPTION
## Summary
- implement counterattack roll after each fight
- add attack-slide animation when goblin deals damage
- use attack-slide whenever goblin attack or counterattacks

## Testing
- `npm test`
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847fa46c1f4832684b36c731868c81c