### PR TITLE
Fix trap room ending turn

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -388,7 +388,7 @@ function App() {
       const newBoard = board.map(row => row.map(tile => ({ ...tile })))
       const tile = newBoard[trap.position.row][trap.position.col]
       tile.trapResolved = success
-      let newHero = { ...hero }
+      let newHero = { ...hero, movement: 0, ap: 0 }
       let discard = null
       let reward = prev.reward
       if (success) {


### PR DESCRIPTION
## Summary
- end the hero turn after resolving a trap by clearing movement and AP

## Testing
- `npm run lint --prefix frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68490331c5808326994b289dac7c6a95