### PR TITLE
Improve hero selection screen styling

### DIFF
--- a/frontend/src/components/HeroSelect.jsx
+++ b/frontend/src/components/HeroSelect.jsx
@@ -9,7 +9,7 @@ function HeroSelect({ onSelect }) {
       <div className="hero-options">
         {Object.entries(HERO_TYPES).map(([key, hero]) => (
           <button key={key} onClick={() => onSelect(key)}>
-            <img src={hero.image} alt={hero.name} width="40" height="40" />
+            <img src={hero.image} alt={hero.name} />
             <div>{hero.name}</div>
           </button>
         ))}

--- a/frontend/src/components/HeroSelect.scss
+++ b/frontend/src/components/HeroSelect.scss
@@ -1,18 +1,40 @@
 .hero-select {
   text-align: center;
+  margin-top: 2rem;
+
+  h2 {
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+  }
 
   .hero-options {
     display: flex;
-    gap: 1rem;
+    gap: 2rem;
     justify-content: center;
+    flex-wrap: wrap;
 
     button {
-      padding: 0.5rem 1rem;
-      font-size: 1rem;
+      padding: 1rem 1.5rem;
+      font-size: 1.2rem;
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 0.25rem;
+      gap: 0.5rem;
+      background: #f5f5f5;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+      img {
+        width: 8rem;
+        height: auto;
+        border-radius: 0.25rem;
+      }
+
+      &:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- update `HeroSelect.jsx` to rely on CSS sizing
- redesign hero selection styles for larger, non-square portraits

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6849bd1b1d0883268e9aa4b73f4a207c