### PR TITLE
Add trap evasion and disarm flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The hero panel now displays these attributes along with a portrait image for the
 
 ### Trap Disarming
 
-Stepping into a trapped room first requires an **evasion** roll. Roll your hero's *agility* dice and if the best result meets or exceeds the trap difficulty you avoid the initial damage. Whether you succeed or not you may then spend **1 AP** to attempt a disarm check. Disarming works like a combat roll: select one die of 3 or higher as your base and any dice showing 1–2 as add-ons. If the total meets or exceeds the trap difficulty the trap is disarmed and you earn a random item plus any unused dice rewards (extra AP or HP). Failure deals the trap damage again and leaves it active. Unresolved trap rooms are highlighted in red with a warning icon so you can easily spot them on the board.
+Stepping into a trapped room first requires an **evasion** roll. Roll your *agility* dice, choose one die of 3 or higher as your base and any dice showing 1–2 as add‑ons. If the total meets or exceeds the trap difficulty you take no damage and gain any unused‑dice rewards. Whether you succeed or not you may then spend **1 AP** to attempt a disarm check. Disarming works the same way: pick a base die of 3+ and add any 1–2 dice. Success disarms the trap for a random item and unused‑dice rewards; failure deals the trap damage again and leaves it active. Unresolved trap rooms are highlighted in red with a warning icon so you can easily spot them on the board.
 
 ### Customizing Hero Stats
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ The hero panel now displays these attributes along with a portrait image for the
 
 ### Trap Disarming
 
-When you enter a room with a trap you may attempt to disarm it. Roll your hero's
-*agility* dice and take the highest result. If the roll meets or exceeds the trap's listed difficulty the trap is disarmed and you receive a random treasure. Failure keeps the trap active and deals damage, so decide carefully. Unresolved trap rooms are highlighted in red with a warning icon so you can easily spot them on the board.
+Stepping into a trapped room first requires an **evasion** roll. Roll your hero's *agility* dice and if the best result meets or exceeds the trap difficulty you avoid the initial damage. Whether you succeed or not you may then spend **1 AP** to attempt a disarm roll using the same difficulty. Success grants a random treasure and removes the trap, while failure deals the trap damage again and leaves it active. Unresolved trap rooms are highlighted in red with a warning icon so you can easily spot them on the board.
 
 ### Customizing Hero Stats
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The hero panel now displays these attributes along with a portrait image for the
 
 ### Trap Disarming
 
-Stepping into a trapped room first requires an **evasion** roll. Roll your hero's *agility* dice and if the best result meets or exceeds the trap difficulty you avoid the initial damage. Whether you succeed or not you may then spend **1 AP** to attempt a disarm roll using the same difficulty. Success grants a random treasure and removes the trap, while failure deals the trap damage again and leaves it active. Unresolved trap rooms are highlighted in red with a warning icon so you can easily spot them on the board.
+Stepping into a trapped room first requires an **evasion** roll. Roll your hero's *agility* dice and if the best result meets or exceeds the trap difficulty you avoid the initial damage. Whether you succeed or not you may then spend **1 AP** to attempt a disarm check. Disarming works like a combat roll: select one die of 3 or higher as your base and any dice showing 1–2 as add-ons. If the total meets or exceeds the trap difficulty the trap is disarmed and you earn a random item plus any unused dice rewards (extra AP or HP). Failure deals the trap damage again and leaves it active. Unresolved trap rooms are highlighted in red with a warning icon so you can easily spot them on the board.
 
 ### Customizing Hero Stats
 

--- a/frontend/src/components/EncounterModal.scss
+++ b/frontend/src/components/EncounterModal.scss
@@ -299,6 +299,16 @@
   }
 }
 
+.hero-dice {
+  width: 40px;
+  height: 40px;
+  background: url('/dice.png') center/contain no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
 .dice-shake {
   animation: shake 0.6s;
 }

--- a/frontend/src/components/RewardModal.jsx
+++ b/frontend/src/components/RewardModal.jsx
@@ -9,7 +9,9 @@ function RewardModal({ reward, onConfirm }) {
       <div className="encounter-window">
         <h2>You got a reward!</h2>
         <p className="reward-info">
-          1 random item{reward.hp ? ` and ${reward.hp} hp` : ''}
+          1 random item
+          {reward.hp ? ` and ${reward.hp} hp` : ''}
+          {reward.ap ? ` and ${reward.ap} ap` : ''}
         </p>
         <div
           className={`reward-card ${revealed ? 'revealed' : ''}`}

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './RoomTile.scss';
-import { DISARM_RULE } from '../trapRules';
+import { DISARM_RULE, EVASION_RULE } from '../trapRules';
 
 const DIRS = ['up', 'down', 'left', 'right'];
 
@@ -13,9 +13,9 @@ function RoomTile({ tile, onClick, highlight, disabled }) {
       title={
         tile.revealed
           ? tile.roomId +
-          (tile.trap && !tile.trapResolved
-            ? ` - ${DISARM_RULE} Difficulty ${tile.trap.difficulty}.`
-            : '')
+            (tile.trap && !tile.trapResolved
+              ? ` - ${EVASION_RULE} Difficulty ${tile.trap.difficulty}. ${DISARM_RULE}`
+              : '')
           : undefined
       }
     >
@@ -42,7 +42,7 @@ function RoomTile({ tile, onClick, highlight, disabled }) {
           title={
             tile.trapResolved
               ? 'Trap disarmed'
-              : `${DISARM_RULE} Difficulty ${tile.trap.difficulty}.`
+              : `${EVASION_RULE} Difficulty ${tile.trap.difficulty}. ${DISARM_RULE}`
           }
         >
           {tile.trapResolved ? '✅' : tile.trap.icon}

--- a/frontend/src/components/TrapModal.jsx
+++ b/frontend/src/components/TrapModal.jsx
@@ -1,35 +1,70 @@
 import React, { useState } from 'react'
 import './EncounterModal.scss'
 import { DISARM_RULE, EVASION_RULE } from '../trapRules'
+import { computeAttackBreakdown, computeUnusedRewards } from '../fightUtils'
 
 function TrapModal({ hero, trap, onResolve }) {
-  const [stage, setStage] = useState('evasion')
+  const [stage, setStage] = useState('evasionReady')
   const [evasionRolls, setEvasionRolls] = useState([])
   const [evaded, setEvaded] = useState(null)
   const [disarmRolls, setDisarmRolls] = useState([])
+  const [baseIdx, setBaseIdx] = useState(null)
+  const [extraIdxs, setExtraIdxs] = useState([])
   const [disarmSuccess, setDisarmSuccess] = useState(null)
+  const [rewards, setRewards] = useState(null)
 
-  const roll = () => Array.from({ length: hero.agilityDice }, () => Math.ceil(Math.random() * 6))
+  const roll = () =>
+    Array.from({ length: hero.agilityDice }, () => Math.ceil(Math.random() * 6))
 
-  const attemptEvasion = () => {
-    const r = roll()
-    setEvasionRolls(r)
-    setEvaded(Math.max(...r) >= trap.difficulty)
-    setStage('postEvasion')
+  const startEvasion = () => {
+    setStage('evasionRoll')
+    setTimeout(() => {
+      const r = roll()
+      setEvasionRolls(r)
+      setEvaded(Math.max(...r) >= trap.difficulty)
+      setStage('postEvasion')
+    }, 600)
   }
 
-  const attemptDisarm = () => {
-    const r = roll()
-    setDisarmRolls(r)
-    setDisarmSuccess(Math.max(...r) >= trap.difficulty)
+  const startDisarm = () => {
+    setStage('disarmRoll')
+    setTimeout(() => {
+      const r = roll()
+      setDisarmRolls(r)
+      setBaseIdx(null)
+      setExtraIdxs([])
+      setStage('disarmSelect')
+    }, 600)
+  }
+
+  const confirmDisarm = () => {
+    const details = computeAttackBreakdown(
+      {},
+      { attack: 0 },
+      disarmRolls,
+      baseIdx,
+      extraIdxs,
+    )
+    const success = details.total >= trap.difficulty
+    setRewards(success ? computeUnusedRewards(disarmRolls, baseIdx, extraIdxs) : { ap: 0, hp: 0 })
+    setDisarmSuccess(success)
     setStage('done')
   }
 
-  const skip = () => onResolve({ evaded, disarm: undefined, evasionRolls, disarmRolls: [] })
+  const skip = () =>
+    onResolve({ evaded, disarm: undefined, evasionRolls, disarmRolls: [] })
 
   const close = () => {
     if (disarmSuccess !== null) {
-      onResolve({ evaded, disarm: disarmSuccess, evasionRolls, disarmRolls })
+      onResolve({
+        evaded,
+        disarm: disarmSuccess,
+        evasionRolls,
+        disarmRolls,
+        baseIdx,
+        extraIdxs,
+        rewards,
+      })
     }
   }
 
@@ -44,28 +79,138 @@ function TrapModal({ hero, trap, onResolve }) {
           <span className="trap-icon">{trap.icon}</span>
           <span className="trap-name">{trapName}</span>
         </div>
-        {stage === 'evasion' && (
+        {stage === 'evasionReady' && (
           <>
             <p className="trap-info">{EVASION_RULE}</p>
             <p className="trap-difficulty">Need {trap.difficulty}+ on the highest die.</p>
+            <div className="dice-container">
+              {Array.from({ length: hero.agilityDice }).map((_, idx) => (
+                <div key={idx} className="hero-dice" />
+              ))}
+            </div>
             <div className="buttons">
-              <button onClick={attemptEvasion}>Evade</button>
+              <button onClick={startEvasion}>Roll</button>
             </div>
           </>
+        )}
+        {stage === 'evasionRoll' && (
+          <div className="trap-result">
+            <div className="dice-container">
+              {Array.from({ length: hero.agilityDice }).map((_, idx) => (
+                <div key={idx} className="hero-dice dice-shake" />
+              ))}
+            </div>
+          </div>
         )}
         {stage === 'postEvasion' && (
           <div className="trap-result">
             <div className="dice-container">
               {evasionRolls.map((v, idx) => (
-                <div key={idx} className="dice">{v}</div>
+                <div key={idx} className="hero-dice">{v}</div>
               ))}
             </div>
             <div className="info">
               {evaded ? 'Evaded the trap!' : `Took ${trap.damage} damage!`}
             </div>
             <div className="buttons">
-              {hero.ap > 0 && <button onClick={attemptDisarm}>Disarm (1 AP)</button>}
+              {hero.ap > 0 && <button onClick={() => setStage('disarmReady')}>Disarm (1 AP)</button>}
               <button onClick={skip}>Continue</button>
+            </div>
+          </div>
+        )}
+        {stage === 'disarmReady' && (
+          <div className="trap-result">
+            <div className="dice-container">
+              {Array.from({ length: hero.agilityDice }).map((_, idx) => (
+                <div key={idx} className="hero-dice" />
+              ))}
+            </div>
+            <div className="info">{DISARM_RULE}</div>
+            <div className="buttons">
+              <button onClick={startDisarm}>Roll</button>
+              <button onClick={skip}>Cancel</button>
+            </div>
+          </div>
+        )}
+        {stage === 'disarmRoll' && (
+          <div className="trap-result">
+            <div className="dice-container">
+              {Array.from({ length: hero.agilityDice }).map((_, idx) => (
+                <div key={idx} className="hero-dice dice-shake" />
+              ))}
+            </div>
+          </div>
+        )}
+        {stage === 'disarmSelect' && (
+          <div className="trap-result">
+            <div className="dice-container">
+              {disarmRolls.map((v, idx) => {
+                const isBase = idx === baseIdx
+                const isExtra = extraIdxs.includes(idx)
+                const classes = ['dice']
+                if (isBase) classes.push('base')
+                if (v >= 3) {
+                  classes.push('selectable')
+                } else {
+                  classes.push(baseIdx === null ? 'disabled' : 'selectable')
+                  if (isExtra) classes.push('extra')
+                }
+                const handleClick = () => {
+                  if (v >= 3) {
+                    setBaseIdx(idx)
+                    setExtraIdxs([])
+                  } else if (baseIdx !== null) {
+                    setExtraIdxs(prev =>
+                      prev.includes(idx) ? prev.filter(i => i !== idx) : [...prev, idx],
+                    )
+                  }
+                }
+                return (
+                  <div key={idx} className={classes.join(' ')} onClick={handleClick}>
+                    <div className="dice-value">
+                      {v < 3 && <img src="/add-icon.png" alt="+" className="plus-icon" />}
+                      {v}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+            <div className="info">
+              {baseIdx === null
+                ? disarmRolls.some(v => v >= 3)
+                  ? 'Choose a base die (>=3).'
+                  : 'No die is high enough for a base roll.'
+                : (() => {
+                    const details = computeAttackBreakdown(
+                      {},
+                      { attack: 0 },
+                      disarmRolls,
+                      baseIdx,
+                      extraIdxs,
+                    )
+                    const r = computeUnusedRewards(disarmRolls, baseIdx, extraIdxs)
+                    const parts = []
+                    if (details.base) parts.push(`${details.base} base`)
+                    if (details.extra) parts.push(`${details.extra} extra`)
+                    const rewardParts = []
+                    if (r.ap) rewardParts.push(`${r.ap} ap`)
+                    if (r.hp) rewardParts.push(`${r.hp} hp`)
+                    return (
+                      <>
+                        {`Need ${trap.difficulty}, power ${details.total} (${parts.join(' + ')})`}
+                        {rewardParts.length ? (
+                          <>
+                            <br />Unused dice reward: {rewardParts.join(' and ')}
+                          </>
+                        ) : null}
+                      </>
+                    )
+                  })()}
+            </div>
+            <div className="buttons">
+              <button onClick={confirmDisarm} disabled={disarmRolls.some(v => v >= 3) && baseIdx === null}>
+                Disarm
+              </button>
             </div>
           </div>
         )}
@@ -73,11 +218,18 @@ function TrapModal({ hero, trap, onResolve }) {
           <div className="trap-result">
             <div className="dice-container">
               {disarmRolls.map((v, idx) => (
-                <div key={idx} className="dice">{v}</div>
+                <div key={idx} className="hero-dice">{v}</div>
               ))}
             </div>
             <div className="info">
               {disarmSuccess ? 'Successfully disarmed!' : 'Failed to disarm.'}
+              {disarmSuccess && rewards && (rewards.ap || rewards.hp) ? (
+                <>
+                  <br />Reward: {rewards.ap ? `${rewards.ap} ap` : ''}
+                  {rewards.ap && rewards.hp ? ' and ' : ''}
+                  {rewards.hp ? `${rewards.hp} hp` : ''}
+                </>
+              ) : null}
             </div>
             <div className="buttons">
               <button onClick={close}>OK</button>

--- a/frontend/src/trapRules.js
+++ b/frontend/src/trapRules.js
@@ -1,5 +1,5 @@
 export const EVASION_RULE =
-  "Roll your hero's agility dice. If the best result meets or exceeds the trap difficulty you avoid the damage.";
+  "Roll your agility dice then pick a die of 3+ as the base and any 1-2 dice as add-ons. If the total meets the trap difficulty you evade.";
 
 export const DISARM_RULE =
   "Spend 1 AP and roll your agility dice. Choose a die of 3+ as the base and any 1-2 dice as add-ons. If the total meets or exceeds the trap difficulty the trap is disarmed and you gain the reward.";

--- a/frontend/src/trapRules.js
+++ b/frontend/src/trapRules.js
@@ -1,5 +1,8 @@
+export const EVASION_RULE =
+  "Roll your hero's agility dice. If the best result meets or exceeds the trap difficulty you avoid the damage.";
+
 export const DISARM_RULE =
-  "Roll your hero's agility dice and take the highest result. If it meets or exceeds the trap difficulty, the trap is disarmed.";
+  "Spend 1 AP and roll your agility dice. If the best result meets or exceeds the trap difficulty the trap is disarmed and you gain the reward.";
 
 export const TRAP_TYPES = {
   snare: {

--- a/frontend/src/trapRules.js
+++ b/frontend/src/trapRules.js
@@ -2,7 +2,7 @@ export const EVASION_RULE =
   "Roll your hero's agility dice. If the best result meets or exceeds the trap difficulty you avoid the damage.";
 
 export const DISARM_RULE =
-  "Spend 1 AP and roll your agility dice. If the best result meets or exceeds the trap difficulty the trap is disarmed and you gain the reward.";
+  "Spend 1 AP and roll your agility dice. Choose a die of 3+ as the base and any 1-2 dice as add-ons. If the total meets or exceeds the trap difficulty the trap is disarmed and you gain the reward.";
 
 export const TRAP_TYPES = {
   snare: {


### PR DESCRIPTION
## Summary
- introduce trap evasion step and 1 AP disarm attempt
- update trap modal UI for evasion and disarm
- adjust trap handling logic in `App.jsx`
- clarify trap rules in README
- update tooltips for trap rooms

## Testing
- `npm test`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6849dae67bc08326a94871659f0d34a5