### PR TITLE
Add hero card to trap modal

### DIFF
--- a/frontend/src/components/TrapModal.jsx
+++ b/frontend/src/components/TrapModal.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import './EncounterModal.scss'
 import { DISARM_RULE, EVASION_RULE } from '../trapRules'
 import { computeAttackBreakdown, computeUnusedRewards } from '../fightUtils'
+import HeroPanel from './HeroPanel'
 
 function TrapModal({ hero, trap, onResolve }) {
   const [stage, setStage] = useState('evasionReady')
@@ -341,6 +342,7 @@ function TrapModal({ hero, trap, onResolve }) {
             </div>
           </div>
         )}
+        <HeroPanel hero={hero} />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- import `HeroPanel` in `TrapModal`
- render the hero panel at the end of the trap window so the player can see hero status when dealing with traps

## Testing
- `npm install`
- `npm test`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6849e42b1970832687b6383a4c3a9299