### PR TITLE
Add ranged agility weapons

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -285,7 +285,6 @@ function App() {
     (r, c) => {
       const { hero, board, encounter } = state
       if (!hero || encounter) return
-      if (board[hero.row][hero.col].goblin) return
       const tile = board[r][c]
       if (!tile.goblin || tile.goblin.hp <= 0) return
 
@@ -340,7 +339,6 @@ function App() {
   const rangedTargets = useMemo(() => {
     const { hero, board, encounter } = state
     if (!hero || encounter) return []
-    if (board[hero.row][hero.col].goblin) return []
     const targets = []
     hero.weapons.forEach(w => {
       if (w.attackType === 'range' && w.dice === 'agility' && w.range > 0) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,7 +16,7 @@ import { HERO_TYPES } from './heroData'
 import { GOBLIN_TYPES, randomGoblinType } from './goblinData'
 import { randomTreasure, adaptTreasureItem } from './treasureDeck'
 import { formatFightLogs } from './fightUtils'
-import { getRangedTargets, opposite } from './boardUtils'
+import { getRangedTargets, opposite, distanceToTarget } from './boardUtils'
 
 const BOARD_SIZE = 7
 const CENTER = Math.floor(BOARD_SIZE / 2)
@@ -263,7 +263,7 @@ function App() {
           goblin: { ...newBoard[r][c].goblin },
           position: { row: r, col: c },
           prev: { row: hero.row, col: hero.col },
-          allowRanged: false,
+          distance: 0,
         }
       }
 
@@ -300,13 +300,16 @@ function App() {
       )
       if (!inRange) return
 
+      const dist = distanceToTarget(board, hero, r, c)
+      if (dist === Infinity) return
+
       setState(prev => ({
         ...prev,
         encounter: {
           goblin: { ...tile.goblin },
           position: { row: r, col: c },
           prev: { row: hero.row, col: hero.col },
-          allowRanged: true,
+          distance: dist,
         },
       }))
       addLog(`${hero.name} attacks ${tile.goblin.name} from afar`)
@@ -632,7 +635,7 @@ function App() {
           goblin={state.encounter.goblin}
           hero={state.hero}
           goblinCount={goblinCount}
-          allowRanged={state.encounter.allowRanged}
+          distance={state.encounter.distance}
           onReward={applyDiceRewards}
           onSkill={applySkillCost}
           onFight={handleFight}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -319,23 +319,17 @@ function App() {
     [state, addLog],
   )
 
-  const promptMove = useCallback((r, c) => {
-    setActionPrompt({ type: 'move', row: r, col: c })
-  }, [])
-
   const promptAttack = useCallback((r, c) => {
     setActionPrompt({ type: 'attack', row: r, col: c })
   }, [])
 
   const confirmAction = useCallback(() => {
     if (!actionPrompt) return
-    if (actionPrompt.type === 'move') {
-      moveHero(actionPrompt.row, actionPrompt.col)
-    } else if (actionPrompt.type === 'attack') {
+    if (actionPrompt.type === 'attack') {
       shootGoblin(actionPrompt.row, actionPrompt.col)
     }
     setActionPrompt(null)
-  }, [actionPrompt, moveHero, shootGoblin])
+  }, [actionPrompt, shootGoblin])
 
   const cancelAction = useCallback(() => setActionPrompt(null), [])
 
@@ -622,7 +616,7 @@ function App() {
                   move={move}
                   attack={attack}
                   disabled={disabled}
-                  onMove={() => promptMove(rIdx, cIdx)}
+                  onMove={() => moveHero(rIdx, cIdx)}
                   onAttack={() => promptAttack(rIdx, cIdx)}
                 />
               )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,7 +16,7 @@ import { HERO_TYPES } from './heroData'
 import { GOBLIN_TYPES, randomGoblinType } from './goblinData'
 import { randomTreasure, adaptTreasureItem } from './treasureDeck'
 import { formatFightLogs } from './fightUtils'
-import { getRangedTargets } from './boardUtils'
+import { getRangedTargets, opposite } from './boardUtils'
 
 const BOARD_SIZE = 7
 const CENTER = Math.floor(BOARD_SIZE / 2)
@@ -30,22 +30,6 @@ function directionFromDelta(dr, dc) {
   if (dc === 1) return 'right'
   return null
 }
-
-function opposite(dir) {
-  switch (dir) {
-    case 'up':
-      return 'down'
-    case 'down':
-      return 'up'
-    case 'left':
-      return 'right'
-    case 'right':
-      return 'left'
-    default:
-      return null
-  }
-}
-
 
 function createEmptyBoard() {
   return Array.from({ length: BOARD_SIZE }, (_, r) =>
@@ -301,6 +285,7 @@ function App() {
     (r, c) => {
       const { hero, board, encounter } = state
       if (!hero || encounter) return
+      if (board[hero.row][hero.col].goblin) return
       const tile = board[r][c]
       if (!tile.goblin || tile.goblin.hp <= 0) return
 
@@ -355,6 +340,7 @@ function App() {
   const rangedTargets = useMemo(() => {
     const { hero, board, encounter } = state
     if (!hero || encounter) return []
+    if (board[hero.row][hero.col].goblin) return []
     const targets = []
     hero.weapons.forEach(w => {
       if (w.attackType === 'range' && w.dice === 'agility' && w.range > 0) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -263,6 +263,7 @@ function App() {
           goblin: { ...newBoard[r][c].goblin },
           position: { row: r, col: c },
           prev: { row: hero.row, col: hero.col },
+          allowRanged: false,
         }
       }
 
@@ -305,6 +306,7 @@ function App() {
           goblin: { ...tile.goblin },
           position: { row: r, col: c },
           prev: { row: hero.row, col: hero.col },
+          allowRanged: true,
         },
       }))
       addLog(`${hero.name} attacks ${tile.goblin.name} from afar`)
@@ -592,6 +594,7 @@ function App() {
                   key={`${rIdx}-${cIdx}`}
                   tile={tile}
                   highlight={move || attack}
+                  attackable={attack}
                   disabled={disabled}
                   onClick={() => (move ? moveHero(rIdx, cIdx) : attack ? shootGoblin(rIdx, cIdx) : null)}
                 />
@@ -629,6 +632,7 @@ function App() {
           goblin={state.encounter.goblin}
           hero={state.hero}
           goblinCount={goblinCount}
+          allowRanged={state.encounter.allowRanged}
           onReward={applyDiceRewards}
           onSkill={applySkillCost}
           onFight={handleFight}

--- a/frontend/src/boardUtils.js
+++ b/frontend/src/boardUtils.js
@@ -42,3 +42,24 @@ export function getRangedTargets(board, hero, range) {
   return targets;
 }
 
+export function distanceToTarget(board, hero, row, col) {
+  if (hero.row === row && hero.col === col) return 0;
+  if (hero.row !== row && hero.col !== col) return Infinity;
+  const dir = hero.row === row ? (col > hero.col ? 'right' : 'left') : (row > hero.row ? 'down' : 'up');
+  const [dr, dc] = dir === 'up' ? [-1, 0] : dir === 'down' ? [1, 0] : dir === 'left' ? [0, -1] : [0, 1];
+  let r = hero.row;
+  let c = hero.col;
+  let tile = board[r][c];
+  let steps = 0;
+  while (r !== row || c !== col) {
+    if (!tile.paths[dir]) return Infinity;
+    r += dr;
+    c += dc;
+    if (r < 0 || r >= board.length || c < 0 || c >= board[0].length) return Infinity;
+    const next = board[r][c];
+    if (!next.revealed || !next.paths[opposite(dir)]) return Infinity;
+    steps++;
+    tile = next;
+  }
+  return steps;
+}

--- a/frontend/src/boardUtils.js
+++ b/frontend/src/boardUtils.js
@@ -1,0 +1,44 @@
+export function opposite(dir) {
+  switch (dir) {
+    case 'up':
+      return 'down';
+    case 'down':
+      return 'up';
+    case 'left':
+      return 'right';
+    case 'right':
+      return 'left';
+    default:
+      return null;
+  }
+}
+
+export function getRangedTargets(board, hero, range) {
+  const dirs = {
+    up: [-1, 0],
+    down: [1, 0],
+    left: [0, -1],
+    right: [0, 1],
+  };
+  const targets = [];
+  Object.entries(dirs).forEach(([dir, [dr, dc]]) => {
+    let r = hero.row;
+    let c = hero.col;
+    let tile = board[r][c];
+    for (let step = 0; step < range; step++) {
+      if (!tile.paths[dir]) break;
+      r += dr;
+      c += dc;
+      if (r < 0 || r >= board.length || c < 0 || c >= board[0].length) break;
+      const next = board[r][c];
+      if (!next.revealed || !next.paths[opposite(dir)]) break;
+      if (next.goblin && next.goblin.hp > 0) {
+        targets.push({ row: r, col: c });
+        break;
+      }
+      tile = next;
+    }
+  });
+  return targets;
+}
+

--- a/frontend/src/components/ConfirmModal.jsx
+++ b/frontend/src/components/ConfirmModal.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import './EncounterModal.scss'
+
+function ConfirmModal({ message, onConfirm, onCancel }) {
+  return (
+    <div className="encounter-overlay">
+      <div className="encounter-window">
+        <p>{message}</p>
+        <div className="buttons">
+          <button onClick={onConfirm}>Yes</button>
+          <button onClick={onCancel}>No</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ConfirmModal

--- a/frontend/src/components/ConfirmModal.jsx
+++ b/frontend/src/components/ConfirmModal.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import './EncounterModal.scss'
+import './ConfirmModal.scss'
 
 function ConfirmModal({ message, onConfirm, onCancel }) {
   return (
-    <div className="encounter-overlay">
-      <div className="encounter-window">
+    <div className="confirm-overlay">
+      <div className="confirm-box">
         <p>{message}</p>
         <div className="buttons">
           <button onClick={onConfirm}>Yes</button>

--- a/frontend/src/components/ConfirmModal.scss
+++ b/frontend/src/components/ConfirmModal.scss
@@ -1,0 +1,30 @@
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 20;
+}
+
+.confirm-box {
+  background: #222;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  text-align: center;
+  font-size: 0.9rem;
+
+  .buttons {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    justify-content: center;
+
+    button {
+      font-size: 0.8rem;
+      padding: 0 6px;
+    }
+  }
+}

--- a/frontend/src/components/EncounterModal.jsx
+++ b/frontend/src/components/EncounterModal.jsx
@@ -26,14 +26,21 @@ function rewardInfo(value) {
   }
 }
 
-function EncounterModal({ goblin, hero, goblinCount, onFight, onFlee, onReward, onSkill }) {
+function EncounterModal({ goblin, hero, goblinCount, allowRanged = false, onFight, onFlee, onReward, onSkill }) {
   const [stage, setStage] = useState('menu')
   const [rolls, setRolls] = useState([])
   const [baseIdx, setBaseIdx] = useState(null)
   const [extraIdxs, setExtraIdxs] = useState([])
+  const firstRangedIdx = hero.weapons.findIndex(w => w.attackType === 'range')
   const firstMeleeIdx = hero.weapons.findIndex(w => w.attackType !== 'range')
   const [weaponIdx, setWeaponIdx] = useState(
-    firstMeleeIdx >= 0 ? firstMeleeIdx : 0,
+    allowRanged
+      ? firstRangedIdx >= 0
+        ? firstRangedIdx
+        : 0
+      : firstMeleeIdx >= 0
+      ? firstMeleeIdx
+      : 0,
   )
   const [result, setResult] = useState(null)
   const [counterPhase, setCounterPhase] = useState(null)
@@ -60,9 +67,11 @@ function EncounterModal({ goblin, hero, goblinCount, onFight, onFlee, onReward, 
   }, [hero])
 
   useEffect(() => {
-    const idx = hero.weapons.findIndex(w => w.attackType !== 'range')
+    const idx = allowRanged
+      ? hero.weapons.findIndex(w => w.attackType === 'range')
+      : hero.weapons.findIndex(w => w.attackType !== 'range')
     setWeaponIdx(idx >= 0 ? idx : 0)
-  }, [hero])
+  }, [hero, allowRanged])
 
   useEffect(() => {
     const t1 = setTimeout(() => setShake(false), 400)
@@ -322,7 +331,7 @@ function EncounterModal({ goblin, hero, goblinCount, onFight, onFlee, onReward, 
                       type="radio"
                       checked={weaponIdx === idx}
                       onChange={() => setWeaponIdx(idx)}
-                      disabled={w.attackType === 'range'}
+                      disabled={!allowRanged && w.attackType === 'range'}
                     />
                     <ItemCard item={w} />
                   </label>
@@ -342,7 +351,7 @@ function EncounterModal({ goblin, hero, goblinCount, onFight, onFlee, onReward, 
               <div className="buttons">
                 <button
                   onClick={startFight}
-                  disabled={hero.weapons[weaponIdx].attackType === 'range'}
+                  disabled={!allowRanged && hero.weapons[weaponIdx].attackType === 'range'}
                 >
                   Fight
                 </button>

--- a/frontend/src/components/EncounterModal.jsx
+++ b/frontend/src/components/EncounterModal.jsx
@@ -31,7 +31,10 @@ function EncounterModal({ goblin, hero, goblinCount, onFight, onFlee, onReward, 
   const [rolls, setRolls] = useState([])
   const [baseIdx, setBaseIdx] = useState(null)
   const [extraIdxs, setExtraIdxs] = useState([])
-  const [weaponIdx, setWeaponIdx] = useState(0)
+  const firstMeleeIdx = hero.weapons.findIndex(w => w.attackType !== 'range')
+  const [weaponIdx, setWeaponIdx] = useState(
+    firstMeleeIdx >= 0 ? firstMeleeIdx : 0,
+  )
   const [result, setResult] = useState(null)
   const [counterPhase, setCounterPhase] = useState(null)
   const [counterMsg, setCounterMsg] = useState('')
@@ -54,6 +57,11 @@ function EncounterModal({ goblin, hero, goblinCount, onFight, onFlee, onReward, 
 
   useEffect(() => {
     setDisplayHero(hero)
+  }, [hero])
+
+  useEffect(() => {
+    const idx = hero.weapons.findIndex(w => w.attackType !== 'range')
+    setWeaponIdx(idx >= 0 ? idx : 0)
   }, [hero])
 
   useEffect(() => {
@@ -314,6 +322,7 @@ function EncounterModal({ goblin, hero, goblinCount, onFight, onFlee, onReward, 
                       type="radio"
                       checked={weaponIdx === idx}
                       onChange={() => setWeaponIdx(idx)}
+                      disabled={w.attackType === 'range'}
                     />
                     <ItemCard item={w} />
                   </label>
@@ -331,7 +340,12 @@ function EncounterModal({ goblin, hero, goblinCount, onFight, onFlee, onReward, 
                 </label>
               )}
               <div className="buttons">
-                <button onClick={startFight}>Fight</button>
+                <button
+                  onClick={startFight}
+                  disabled={hero.weapons[weaponIdx].attackType === 'range'}
+                >
+                  Fight
+                </button>
                 <button onClick={startFlee}>Flee</button>
               </div>
             </>

--- a/frontend/src/components/EncounterModal.scss
+++ b/frontend/src/components/EncounterModal.scss
@@ -254,6 +254,12 @@
   input:checked+.item-card {
     box-shadow: 0 0 0 2px yellow;
   }
+
+  input:disabled + .item-card {
+    filter: brightness(0.3);
+    opacity: 0.5;
+    cursor: default;
+  }
 }
 
 .shake {

--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -17,6 +17,12 @@ function ItemCard({ item }) {
           <img src="/add-icon.png" alt="attack" className="plus-icon" />
           <span>{item.attack}</span>
         </div>
+        {item.range ? (
+          <div className="attack-range">
+            <img src="/icon/range-location.png" alt="range" className="range-icon" />
+            <span>{item.range}</span>
+          </div>
+        ) : null}
       </div>
       <div className="weapon-type">
         <img src={typeIcon} alt={item.attackType || 'melee'} />

--- a/frontend/src/components/ItemCard.scss
+++ b/frontend/src/components/ItemCard.scss
@@ -63,6 +63,17 @@
     }
   }
 
+  .attack-range {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+
+    .range-icon {
+      width: 0.5rem;
+      height: 0.5rem;
+    }
+  }
+
   .stat-icon {
     width: 0.8rem;
     height: 0.8rem;

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -4,7 +4,7 @@ import { DISARM_RULE, EVASION_RULE } from '../trapRules';
 
 const DIRS = ['up', 'down', 'left', 'right'];
 
-function RoomTile({ tile, onClick, highlight, disabled }) {
+function RoomTile({ tile, onClick, highlight, disabled, attackable }) {
   return (
     <div
       className={`tile ${tile.revealed ? 'revealed' : ''} ${highlight ? 'possible' : ''} ${!tile.revealed && disabled ? 'disabled' : ''
@@ -31,7 +31,10 @@ function RoomTile({ tile, onClick, highlight, disabled }) {
         </div>
       )}
       {tile.revealed && tile.goblin && (
-        <span className="goblin-icon">{tile.goblin.icon}</span>
+        <div className={`goblin-container${attackable ? ' attackable' : ''}`}>
+          <span className="goblin-icon">{tile.goblin.icon}</span>
+          {attackable && <div className="attack-balloon">Attack?</div>}
+        </div>
       )}
       {tile.revealed && tile.effect === 'death' && (
         <img src="/star.svg" alt="defeated" className="death-effect" />

--- a/frontend/src/components/RoomTile.jsx
+++ b/frontend/src/components/RoomTile.jsx
@@ -4,12 +4,11 @@ import { DISARM_RULE, EVASION_RULE } from '../trapRules';
 
 const DIRS = ['up', 'down', 'left', 'right'];
 
-function RoomTile({ tile, onClick, highlight, disabled, attackable }) {
+function RoomTile({ tile, move, attack, highlight, disabled, onMove, onAttack }) {
   return (
     <div
       className={`tile ${tile.revealed ? 'revealed' : ''} ${highlight ? 'possible' : ''} ${!tile.revealed && disabled ? 'disabled' : ''
         } ${tile.revealed && tile.trap && !tile.trapResolved ? 'trap-room' : ''}`}
-      onClick={onClick}
       title={
         tile.revealed
           ? tile.roomId +
@@ -31,9 +30,14 @@ function RoomTile({ tile, onClick, highlight, disabled, attackable }) {
         </div>
       )}
       {tile.revealed && tile.goblin && (
-        <div className={`goblin-container${attackable ? ' attackable' : ''}`}>
+        <div className="goblin-container">
           <span className="goblin-icon">{tile.goblin.icon}</span>
-          {attackable && <div className="attack-balloon">Attack?</div>}
+        </div>
+      )}
+      {(move || attack) && (
+        <div className="action-buttons">
+          {move && <button onClick={onMove}>Move</button>}
+          {attack && <button onClick={onAttack}>Attack</button>}
         </div>
       )}
       {tile.revealed && tile.effect === 'death' && (

--- a/frontend/src/components/RoomTile.scss
+++ b/frontend/src/components/RoomTile.scss
@@ -123,10 +123,6 @@
     bottom: 2px;
     left: 2px;
     font-size: 0.7rem;
-
-    &.attackable:hover .attack-balloon {
-      display: block;
-    }
   }
 
   .goblin-icon {
@@ -134,20 +130,24 @@
     z-index: 1;
   }
 
-  .attack-balloon {
+
+  .action-buttons {
     display: none;
     position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translate(-50%, -2px);
-    background: white;
-    color: black;
-    border: 1px solid black;
-    border-radius: 3px;
-    padding: 0 2px;
-    white-space: nowrap;
-    font-size: 0.55rem;
-    pointer-events: none;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+
+    button {
+      font-size: 0.6rem;
+      padding: 0 4px;
+    }
+  }
+
+  &.possible:hover .action-buttons {
+    display: flex;
   }
 
   .death-effect {

--- a/frontend/src/components/RoomTile.scss
+++ b/frontend/src/components/RoomTile.scss
@@ -118,11 +118,36 @@
     }
   }
 
-  .goblin-icon {
+  .goblin-container {
     position: absolute;
     bottom: 2px;
     left: 2px;
     font-size: 0.7rem;
+
+    &.attackable:hover .attack-balloon {
+      display: block;
+    }
+  }
+
+  .goblin-icon {
+    position: relative;
+    z-index: 1;
+  }
+
+  .attack-balloon {
+    display: none;
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, -2px);
+    background: white;
+    color: black;
+    border: 1px solid black;
+    border-radius: 3px;
+    padding: 0 2px;
+    white-space: nowrap;
+    font-size: 0.55rem;
+    pointer-events: none;
   }
 
   .death-effect {

--- a/frontend/src/heroData.js
+++ b/frontend/src/heroData.js
@@ -54,6 +54,7 @@ export const HERO_TYPES = {
         dice: 'agility',
         image: '/bow.svg',
         attackType: 'range',
+        range: 3,
       },
       {
         name: 'Dagger',

--- a/frontend/src/treasureDeck.js
+++ b/frontend/src/treasureDeck.js
@@ -51,13 +51,14 @@ export function randomTreasure() {
 }
 
 export function adaptTreasureItem(item) {
+  const attackType = item.attack?.type || 'melee'
   return {
     name: item.name,
     attack: item.attack?.value || 0,
     defence: item.defend || 0,
-    dice: 'strength',
+    dice: attackType === 'range' ? 'agility' : 'strength',
     image: `/weapon/${item.id}.webp`,
-    attackType: item.attack?.type || 'melee',
+    attackType,
     range: item.attack?.range || 0,
   }
 }

--- a/frontend/src/treasureDeck.js
+++ b/frontend/src/treasureDeck.js
@@ -58,5 +58,6 @@ export function adaptTreasureItem(item) {
     dice: 'strength',
     image: `/weapon/${item.id}.webp`,
     attackType: item.attack?.type || 'melee',
+    range: item.attack?.range || 0,
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "postinstall": "npm install --prefix frontend",
-    "test": "node tests/fightFlow.test.mjs"
+    "test": "node tests/fightFlow.test.mjs && node tests/rangeWeapon.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/tests/rangeWeapon.test.mjs
+++ b/tests/rangeWeapon.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'assert';
+import { getRangedTargets } from '../frontend/src/boardUtils.js';
+
+function makeTile(row, col, paths, goblin=null) {
+  return { row, col, revealed: true, paths, goblin };
+}
+
+function createBoard() {
+  const rows = 3;
+  const cols = 4;
+  const board = Array.from({ length: rows }, (_, r) =>
+    Array.from({ length: cols }, (_, c) => makeTile(r, c, { up:false,down:false,left:false,right:false }))
+  );
+  // connect horizontal line in row 1
+  board[1][0].paths.right = true;
+  board[1][1].paths.left = true; board[1][1].paths.right = true;
+  board[1][2].paths.left = true; board[1][2].paths.right = true;
+  board[1][3].paths.left = true;
+  return board;
+}
+
+function testRangedTarget() {
+  const board = createBoard();
+  board[1][3].goblin = { hp: 2 };
+  const hero = { row:1, col:1 };
+  const targets = getRangedTargets(board, hero, 3);
+  assert.deepStrictEqual(targets, [{ row:1, col:3 }]);
+}
+
+function testBlockedPath() {
+  const board = createBoard();
+  board[1][2].paths.left = false; // break path
+  board[1][3].goblin = { hp:2 };
+  const hero = { row:1, col:1 };
+  const targets = getRangedTargets(board, hero, 3);
+  assert.strictEqual(targets.length, 0);
+}
+
+function testOutOfRange() {
+  const board = createBoard();
+  board[1][3].goblin = { hp:2 };
+  const hero = { row:1, col:1 };
+  const targets = getRangedTargets(board, hero, 1);
+  assert.strictEqual(targets.length, 0);
+}
+
+function run() {
+  testRangedTarget();
+  testBlockedPath();
+  testOutOfRange();
+  console.log('All range weapon tests passed');
+}
+
+run();

--- a/tests/rangeWeapon.test.mjs
+++ b/tests/rangeWeapon.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { getRangedTargets } from '../frontend/src/boardUtils.js';
+import { getRangedTargets, distanceToTarget } from '../frontend/src/boardUtils.js';
 
 function makeTile(row, col, paths, goblin=null) {
   return { row, col, revealed: true, paths, goblin };
@@ -44,10 +44,28 @@ function testOutOfRange() {
   assert.strictEqual(targets.length, 0);
 }
 
+function testDistance() {
+  const board = createBoard();
+  board[1][3].goblin = { hp: 2 };
+  const hero = { row: 1, col: 1 };
+  const dist = distanceToTarget(board, hero, 1, 3);
+  assert.strictEqual(dist, 2);
+}
+
+function testDistanceBlocked() {
+  const board = createBoard();
+  board[1][2].paths.left = false;
+  const hero = { row: 1, col: 1 };
+  const dist = distanceToTarget(board, hero, 1, 3);
+  assert.strictEqual(dist, Infinity);
+}
+
 function run() {
   testRangedTarget();
   testBlockedPath();
   testOutOfRange();
+  testDistance();
+  testDistanceBlocked();
   console.log('All range weapon tests passed');
 }
 

--- a/tests/rangeWeapon.test.mjs
+++ b/tests/rangeWeapon.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { getRangedTargets, distanceToTarget } from '../frontend/src/boardUtils.js';
+import { TreasureDeck, adaptTreasureItem } from '../frontend/src/treasureDeck.js';
 
 function makeTile(row, col, paths, goblin=null) {
   return { row, col, revealed: true, paths, goblin };
@@ -60,12 +61,21 @@ function testDistanceBlocked() {
   assert.strictEqual(dist, Infinity);
 }
 
+function testAdaptTreasureItemRangeDice() {
+  const card = TreasureDeck.find(t => t.id === 'stormcaller');
+  const item = adaptTreasureItem(card);
+  assert.strictEqual(item.attackType, 'range');
+  assert.strictEqual(item.range, 6);
+  assert.strictEqual(item.dice, 'agility');
+}
+
 function run() {
   testRangedTarget();
   testBlockedPath();
   testOutOfRange();
   testDistance();
   testDistanceBlocked();
+  testAdaptTreasureItemRangeDice();
   console.log('All range weapon tests passed');
 }
 


### PR DESCRIPTION
## Summary
- add board utility to calculate ranged targets in straight lines
- add ranged bow range and show range icons on items
- allow shooting goblins from distance via agility weapons
- track range when adapting treasure items
- support lint/test setup for new files
- add unit tests for ranged targeting

## Testing
- `npm run lint --prefix frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e88b4dac8326b5dc6f014a85c5d2