### PR TITLE
Display range icons on goblin cards

### DIFF
--- a/frontend/src/components/EncounterModal.scss
+++ b/frontend/src/components/EncounterModal.scss
@@ -326,6 +326,8 @@
 }
 
 .reward-card {
+  width: 100%;
+  height: 100%;
   perspective: 600px;
   margin: 0 auto 0.5rem;
   cursor: pointer;

--- a/frontend/src/components/GoblinCard.jsx
+++ b/frontend/src/components/GoblinCard.jsx
@@ -22,6 +22,10 @@ function GoblinCard({
   const attacks = goblin.attacks || [
     { type: goblin.attackType, attack: goblin.attack, range: goblin.range },
   ];
+  const rangeIcons = {
+    range: '/icon/range-location.png',
+    magic: '/icon/magic-location.png',
+  };
   return (
     <div className={`goblin-card${defeated ? ' shake' : ''}`}>
       <div className="name-bar">{goblin.name}</div>
@@ -43,7 +47,18 @@ function GoblinCard({
             {idx > 0 && <span className="sep"></span>}
             <span className="stat">
               <img src={typeIcons[a.type]} alt={a.type} />+{a.attack}
-              {a.range ? ` (${a.range} tiles)` : ''}
+              {a.range ? (
+                <span className="attack-range">
+                  (
+                  <img
+                    src={rangeIcons[a.type]}
+                    alt="range"
+                    className="range-icon"
+                  />
+                  <span>{a.range}</span>
+                  )
+                </span>
+              ) : null}
             </span>
           </React.Fragment>
         ))}

--- a/frontend/src/components/GoblinCard.scss
+++ b/frontend/src/components/GoblinCard.scss
@@ -52,6 +52,17 @@
       height: 0.7rem;
       margin-right: 0.05rem;
     }
+
+    .attack-range {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.05rem;
+
+      .range-icon {
+        width: 0.7rem;
+        height: 0.7rem;
+      }
+    }
   }
 
   .hp-hearts {


### PR DESCRIPTION
## Summary
- show range-location or magic-location icons on monster stat bars
- style the range display in goblin cards

## Testing
- `npm install`
- `npm run lint --prefix frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b34ff102c83268341e67fcfcb5ef7