### PR TITLE
Fix monster counter logic

### DIFF
--- a/src/components/EncounterModal.jsx
+++ b/src/components/EncounterModal.jsx
@@ -230,6 +230,7 @@ function EncounterModal({ goblin, hero, goblinCount, distance = 0, onFight, onFl
       extraIdxs,
       bonus,
       goblinCount,
+      distance,
     );
     const resultObj = {
       type: 'fight',

--- a/tests/monsterCounter.test.mjs
+++ b/tests/monsterCounter.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import { chooseMonsterAttack, monsterCounter } from '../src/fightUtils.js';
+
+function testChooseAttackOutOfRange() {
+  const goblin = { attacks: [{ type: 'melee', attack: 2 }] };
+  assert.strictEqual(chooseMonsterAttack(goblin, 1), null);
+}
+
+function testChooseAttackRange() {
+  const goblin = { attacks: [ { type: 'melee', attack: 1 }, { type: 'range', attack: 3, range: 3 } ] };
+  const atk = chooseMonsterAttack(goblin, 2);
+  assert.ok(atk && atk.type === 'range');
+}
+
+function testNoCounterWhenOutOfRange() {
+  const hero = { defence: 1 };
+  const weapon = { defence: 0 };
+  const goblin = { attacks: [{ type: 'melee', attack: 2 }], attack:2, attackType:'melee', hp:1 };
+  const res = monsterCounter(hero, weapon, goblin, 2);
+  assert.strictEqual(res, null);
+}
+
+function run() {
+  testChooseAttackOutOfRange();
+  testChooseAttackRange();
+  testNoCounterWhenOutOfRange();
+  console.log('All monster counter tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- allow monsters to pick an attack in range for counterattacks
- pass encounter distance when resolving fights
- expose `chooseMonsterAttack` and adjust counter logic
- add tests for monster counter

## Testing
- `node tests/fightFlow.test.mjs`
- `node tests/rangeWeapon.test.mjs`
- `node tests/monsterCounter.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_684c624d7fb483268b5e62ed12067c65