### PR TITLE
Implement magic attack pathfinding and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node tests/fightFlow.test.mjs && node tests/rangeWeapon.test.mjs"
+    "test": "node tests/fightFlow.test.mjs && node tests/rangeWeapon.test.mjs && node tests/magicWeapon.test.mjs"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -321,10 +321,9 @@ function App() {
       })
       if (!inRange) return
 
-      const dist = Math.min(
-        distanceToTarget(board, hero, r, c),
-        distanceMagic(board, hero, r, c),
-      )
+      const rangeDist = distanceToTarget(board, hero, r, c)
+      const magicDist = distanceMagic(board, hero, r, c)
+      const dist = Math.min(rangeDist, magicDist)
       if (dist === Infinity) return
 
       setState(prev => ({
@@ -333,6 +332,8 @@ function App() {
           goblin: { ...tile.goblin },
           position: { row: r, col: c },
           prev: { row: hero.row, col: hero.col },
+          distanceRange: rangeDist,
+          distanceMagic: magicDist,
           distance: dist,
         },
       }))
@@ -686,7 +687,8 @@ function App() {
           goblin={state.encounter.goblin}
           hero={state.hero}
           goblinCount={goblinCount}
-          distance={state.encounter.distance}
+          distanceRange={state.encounter.distanceRange}
+          distanceMagic={state.encounter.distanceMagic}
           onReward={applyDiceRewards}
           onSkill={applySkillCost}
           onFight={handleFight}

--- a/src/boardUtils.js
+++ b/src/boardUtils.js
@@ -63,3 +63,66 @@ export function distanceToTarget(board, hero, row, col) {
   }
   return steps;
 }
+export function getMagicTargets(board, hero, range) {
+  const dirs = {
+    up: [-1, 0],
+    down: [1, 0],
+    left: [0, -1],
+    right: [0, 1],
+  };
+  const visited = new Set();
+  const queue = [{ r: hero.row, c: hero.col, steps: 0 }];
+  visited.add(`${hero.row},${hero.col}`);
+  const targets = [];
+  while (queue.length > 0) {
+    const { r, c, steps } = queue.shift();
+    if (steps >= range) continue;
+    const tile = board[r][c];
+    Object.entries(dirs).forEach(([dir, [dr, dc]]) => {
+      if (!tile.paths[dir]) return;
+      const nr = r + dr;
+      const nc = c + dc;
+      if (nr < 0 || nr >= board.length || nc < 0 || nc >= board[0].length) return;
+      const next = board[nr][nc];
+      if (!next.revealed || !next.paths[opposite(dir)]) return;
+      const key = `${nr},${nc}`;
+      if (visited.has(key)) return;
+      visited.add(key);
+      if (next.goblin && next.goblin.hp > 0) {
+        targets.push({ row: nr, col: nc });
+      }
+      queue.push({ r: nr, c: nc, steps: steps + 1 });
+    });
+  }
+  return targets;
+}
+
+export function distanceMagic(board, hero, row, col) {
+  const dirs = {
+    up: [-1, 0],
+    down: [1, 0],
+    left: [0, -1],
+    right: [0, 1],
+  };
+  const visited = new Set();
+  const queue = [{ r: hero.row, c: hero.col, steps: 0 }];
+  visited.add(`${hero.row},${hero.col}`);
+  while (queue.length > 0) {
+    const { r, c, steps } = queue.shift();
+    if (r === row && c === col) return steps;
+    const tile = board[r][c];
+    Object.entries(dirs).forEach(([dir, [dr, dc]]) => {
+      if (!tile.paths[dir]) return;
+      const nr = r + dr;
+      const nc = c + dc;
+      if (nr < 0 || nr >= board.length || nc < 0 || nc >= board[0].length) return;
+      const next = board[nr][nc];
+      if (!next.revealed || !next.paths[opposite(dir)]) return;
+      const key = `${nr},${nc}`;
+      if (visited.has(key)) return;
+      visited.add(key);
+      queue.push({ r: nr, c: nc, steps: steps + 1 });
+    });
+  }
+  return Infinity;
+}

--- a/src/components/EncounterModal.jsx
+++ b/src/components/EncounterModal.jsx
@@ -32,8 +32,12 @@ function EncounterModal({ goblin, hero, goblinCount, distance = 0, onFight, onFl
   const [baseIdx, setBaseIdx] = useState(null);
   const [extraIdxs, setExtraIdxs] = useState([]);
   const firstUsableIdx = hero.weapons.findIndex(w => {
-    if (distance === 0) return w.attackType !== 'range';
-    return w.attackType === 'range' && w.range >= distance;
+    if (distance === 0) return w.attackType === 'melee';
+    return (
+      ['range', 'magic'].includes(w.attackType) &&
+      w.range != null &&
+      w.range >= distance
+    );
   });
   const [weaponIdx, setWeaponIdx] = useState(firstUsableIdx >= 0 ? firstUsableIdx : 0);
   const [result, setResult] = useState(null);
@@ -62,8 +66,12 @@ function EncounterModal({ goblin, hero, goblinCount, distance = 0, onFight, onFl
 
   useEffect(() => {
     const idx = hero.weapons.findIndex(w => {
-      if (distance === 0) return w.attackType !== 'range';
-      return w.attackType === 'range' && w.range >= distance;
+      if (distance === 0) return w.attackType === 'melee';
+      return (
+        ['range', 'magic'].includes(w.attackType) &&
+        w.range != null &&
+        w.range >= distance
+      );
     });
     setWeaponIdx(idx >= 0 ? idx : 0);
   }, [hero, distance]);
@@ -327,7 +335,15 @@ function EncounterModal({ goblin, hero, goblinCount, distance = 0, onFight, onFl
                       type="radio"
                       checked={weaponIdx === idx}
                       onChange={() => setWeaponIdx(idx)}
-                      disabled={distance === 0 ? w.attackType === 'range' : !(w.attackType === 'range' && w.range >= distance)}
+                      disabled={
+                        distance === 0
+                          ? w.attackType !== 'melee'
+                          : !(
+                              ['range', 'magic'].includes(w.attackType) &&
+                              w.range != null &&
+                              w.range >= distance
+                            )
+                      }
                     />
                     <ItemCard item={w} />
                   </label>
@@ -349,8 +365,12 @@ function EncounterModal({ goblin, hero, goblinCount, distance = 0, onFight, onFl
                   onClick={startFight}
                   disabled={
                     distance === 0
-                      ? hero.weapons[weaponIdx].attackType === 'range'
-                      : !(hero.weapons[weaponIdx].attackType === 'range' && hero.weapons[weaponIdx].range >= distance)
+                      ? hero.weapons[weaponIdx].attackType !== 'melee'
+                      : !(
+                          ['range', 'magic'].includes(hero.weapons[weaponIdx].attackType) &&
+                          hero.weapons[weaponIdx].range != null &&
+                          hero.weapons[weaponIdx].range >= distance
+                        )
                   }
                 >
                   Fight

--- a/src/treasureDeck.js
+++ b/src/treasureDeck.js
@@ -52,11 +52,14 @@ export function randomTreasure() {
 
 export function adaptTreasureItem(item) {
   const attackType = item.attack?.type || 'melee'
+  let dice = 'strength'
+  if (attackType === 'range') dice = 'agility'
+  if (attackType === 'magic') dice = 'magic'
   return {
     name: item.name,
     attack: item.attack?.value || 0,
     defence: item.defend || 0,
-    dice: attackType === 'range' ? 'agility' : 'strength',
+    dice,
     image: `/weapon/${item.id}.webp`,
     attackType,
     range: item.attack?.range || 0,

--- a/tests/magicWeapon.test.mjs
+++ b/tests/magicWeapon.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'assert';
+import { getMagicTargets, distanceMagic, getRangedTargets, distanceToTarget } from '../src/boardUtils.js';
+import { TreasureDeck, adaptTreasureItem } from '../src/treasureDeck.js';
+import { chooseMonsterAttack } from '../src/fightUtils.js';
+
+function makeTile(row, col, paths, goblin=null) {
+  return { row, col, revealed: true, paths, goblin };
+}
+
+function createBoard() {
+  const rows = 3;
+  const cols = 3;
+  const board = Array.from({ length: rows }, (_, r) =>
+    Array.from({ length: cols }, (_, c) => makeTile(r, c, { up:false,down:false,left:false,right:false }))
+  );
+  // zig-zag path from (0,0) -> (1,0) -> (1,1) -> (0,1) -> (0,2)
+  board[0][0].paths.down = true;
+  board[1][0].paths.up = true; board[1][0].paths.right = true;
+  board[1][1].paths.left = true; board[1][1].paths.up = true; board[1][1].paths.right = true;
+  board[0][1].paths.down = true; board[0][1].paths.right = true;
+  board[0][2].paths.left = true;
+  return board;
+}
+
+function testMagicTarget() {
+  const board = createBoard();
+  board[0][2].goblin = { hp: 2 };
+  const hero = { row:0, col:0 };
+  const targets = getMagicTargets(board, hero, 4);
+  assert.deepStrictEqual(targets, [{ row:0, col:2 }]);
+  const ranged = getRangedTargets(board, hero, 4);
+  assert.strictEqual(ranged.length, 0);
+}
+
+function testMagicDistance() {
+  const board = createBoard();
+  const hero = { row:0, col:0 };
+  const dist = distanceMagic(board, hero, 0, 2);
+  assert.strictEqual(dist, 4);
+  board[1][1].paths.up = false; board[0][1].paths.down = false;
+  const dist2 = distanceMagic(board, hero, 0, 2);
+  assert.strictEqual(dist2, Infinity);
+}
+
+function testAdaptTreasureItemMagicDice() {
+  const card = TreasureDeck.find(t => t.attack?.type === 'magic');
+  const item = adaptTreasureItem(card);
+  assert.strictEqual(item.attackType, 'magic');
+  assert.strictEqual(item.dice, 'magic');
+}
+
+function testMagicCantHitAtZero() {
+  const goblin = { attacks: [{ type:'magic', attack:5, range:3 }] };
+  const atk = chooseMonsterAttack(goblin, 0);
+  assert.strictEqual(atk, null);
+}
+
+function run() {
+  testMagicTarget();
+  testMagicDistance();
+  testAdaptTreasureItemMagicDice();
+  testMagicCantHitAtZero();
+  console.log('All magic weapon tests passed');
+}
+
+run();

--- a/tests/rangeWeapon.test.mjs
+++ b/tests/rangeWeapon.test.mjs
@@ -61,6 +61,23 @@ function testDistanceBlocked() {
   assert.strictEqual(dist, Infinity);
 }
 
+function testZigZagNoTarget() {
+  const board = Array.from({ length: 3 }, (_, r) =>
+    Array.from({ length: 3 }, (_, c) => makeTile(r, c, { up: false, down: false, left: false, right: false }))
+  );
+  board[0][0].paths.down = true;
+  board[1][0].paths.up = true; board[1][0].paths.right = true;
+  board[1][1].paths.left = true; board[1][1].paths.up = true;
+  board[0][1].paths.down = true; board[0][1].paths.right = true;
+  board[0][2].paths.left = true;
+  board[0][2].goblin = { hp: 1 };
+  const hero = { row: 0, col: 0 };
+  const targets = getRangedTargets(board, hero, 4);
+  assert.strictEqual(targets.length, 0);
+  const dist = distanceToTarget(board, hero, 0, 2);
+  assert.strictEqual(dist, Infinity);
+}
+
 function testAdaptTreasureItemRangeDice() {
   const card = TreasureDeck.find(t => t.id === 'stormcaller');
   const item = adaptTreasureItem(card);
@@ -75,6 +92,7 @@ function run() {
   testOutOfRange();
   testDistance();
   testDistanceBlocked();
+  testZigZagNoTarget();
   testAdaptTreasureItemRangeDice();
   console.log('All range weapon tests passed');
 }


### PR DESCRIPTION
## Summary
- add `getMagicTargets` and `distanceMagic` helpers for magic line of sight
- support magic dice in treasure adaptation
- cover magic attack behaviour in new tests
- include magic test in npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6e0eb3f88326a618a294ef731823