### PR TITLE
Add developer tools modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -82,3 +82,14 @@
   }
 }
 
+
+.dev-toggle {
+  position: fixed;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  padding: 2px 6px;
+  font-size: 0.7rem;
+  opacity: 0.5;
+  z-index: 5;
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import TrapModal from './components/TrapModal'
 import { TRAP_TYPES } from './trapRules'
 import DiscardModal from './components/DiscardModal'
 import RewardModal from './components/RewardModal'
-import EventLog from './components/EventLog'
+import DeveloperModal from './components/DeveloperModal'
 import { createShuffledDeck } from './roomDeck'
 import './App.css'
 import { HERO_TYPES } from './heroData'
@@ -141,6 +141,7 @@ function App() {
   const [state, setState] = useState(loadState)
   const [heroDamaged, setHeroDamaged] = useState(false)
   const [eventLog, setEventLog] = useState([])
+  const [showDevModal, setShowDevModal] = useState(false)
   const [actionPrompt, setActionPrompt] = useState(null)
   const prevHpRef = useRef(state.hero ? state.hero.hp : null)
 
@@ -699,8 +700,6 @@ function App() {
           </div>
         )}
         <button onClick={endTurn} className="end-turn">End Turn</button>
-        <button onClick={resetGame} className="reset-game">Reset Game</button>
-        <EventLog log={eventLog} />
       </div>
       {state.encounter && (
         <EncounterModal
@@ -734,6 +733,14 @@ function App() {
           message={`Are you sure you want to ${actionPrompt.message}?`}
           onConfirm={confirmAction}
           onCancel={cancelAction}
+        />
+      )}
+      <button className="dev-toggle" onClick={() => setShowDevModal(true)}>Dev</button>
+      {showDevModal && (
+        <DeveloperModal
+          log={eventLog}
+          onReset={resetGame}
+          onClose={() => setShowDevModal(false)}
         />
       )}
     </div>

--- a/src/components/DeveloperModal.jsx
+++ b/src/components/DeveloperModal.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import EventLog from './EventLog'
+import './DeveloperModal.scss'
+
+function DeveloperModal({ log, onReset, onClose }) {
+  return (
+    <div className="dev-overlay">
+      <div className="dev-modal">
+        <button className="close-dev" onClick={onClose}>&times;</button>
+        <EventLog log={log} />
+        <button onClick={onReset} className="reset-game dev">Reset Game</button>
+      </div>
+    </div>
+  )
+}
+
+export default DeveloperModal

--- a/src/components/DeveloperModal.scss
+++ b/src/components/DeveloperModal.scss
@@ -1,0 +1,38 @@
+.dev-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 15;
+}
+
+.dev-modal {
+  background: #222;
+  color: #fff;
+  padding: 0.5rem;
+  border-radius: 4px;
+  width: 90%;
+  max-width: 320px;
+  max-height: 80vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.close-dev {
+  align-self: flex-end;
+  font-size: 0.8rem;
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+}
+
+.reset-game.dev {
+  width: auto;
+  align-self: center;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- hide reset button and event log behind a developer tools modal
- add small button for toggling developer tools

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c828e7c3883268015418d94b30fe1