### PR TITLE
Implement monster reveal damage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npm test
 - Fleeing now requires rolling agility dice, adding excitement to encounters.
 - Monsters may counterattack. Damage equals the counter roll plus their attack
   and modifiers from special goblins and the number of goblins still alive.
+- Revealing a monster for the first time deals 1 damage to the hero.
 - Ranged and magic attacks respect line of sight and distance.
 - Attacks now animate the target's shield shaking with the damage value popping
   out on a starburst background. Big hits can even shatter the shield in a

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -137,6 +137,7 @@ function App() {
       const newBoard = board.map(row => row.map(tile => ({ ...tile })))
       let newDeck = deck
       const target = newBoard[r][c]
+      let revealedGoblin = false
       if (!target.revealed) {
         const room = newDeck[0]
         const roomId = room.roomId
@@ -150,6 +151,7 @@ function App() {
         if (room.goblin) {
           const typeKey = room.goblin === 'king' ? 'king' : randomGoblinType()
           goblin = { ...GOBLIN_TYPES[typeKey], type: typeKey }
+          revealedGoblin = true
         }
 
         newBoard[r][c] = {
@@ -178,6 +180,10 @@ function App() {
         },
       }
 
+      if (revealedGoblin) {
+        newHero.hp = hero.hp - 1
+      }
+
       let newTrap = null
       if (newBoard[r][c].goblin) {
         newHero.movement = 0
@@ -196,7 +202,10 @@ function App() {
         trap: newTrap,
       }))
       addLog(`${hero.name} moves ${dir}`)
-      if (newBoard[r][c].goblin) addLog(`Encountered ${newBoard[r][c].goblin.name}`)
+      if (newBoard[r][c].goblin) {
+        addLog(`Encountered ${newBoard[r][c].goblin.name}`)
+        if (revealedGoblin) addLog('Ambushed and lost 1 hp')
+      }
       if (newTrap) {
         const t = newTrap.trap
         addLog(`Found trap: ${t.id} (difficulty ${t.difficulty})`)


### PR DESCRIPTION
## Summary
- deduct 1HP when a newly revealed room contains a monster
- describe ambush damage mechanic in the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684efc4a2ab88326b185a43bf3977a0d