### PR TITLE
Add narrative log above hero panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ npm test
   burst of light, permanently removing its defence.
 - Overflow damage now bursts from the target's hearts, and counterattacks show
   the same floating numbers when they hit the hero.
-- Actions are recorded in an event log viewable from the **Dev** button.
+- Actions are recorded in an event log viewable from the **Dev** button, and the
+  latest three entries are shown above the hero card as a narrative feed.
 
 The hero panel now displays these attributes along with a portrait image for the selected hero. Lost HP is shown using the same heart icon tinted black via CSS so you can quickly gauge your health. Dice stats are represented by repeating dice icons rather than numbers.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import DiscardModal from './components/DiscardModal'
 import RewardModal from './components/RewardModal'
 import DeveloperModal from './components/DeveloperModal'
 import GameOverModal from './components/GameOverModal'
+import EventLog from './components/EventLog'
 import './App.css'
 import { HERO_TYPES } from './heroData'
 import { GOBLIN_TYPES, randomGoblinType } from './goblinData'
@@ -77,7 +78,7 @@ function App() {
       },
     }
     setState(prev => ({ ...prev, hero }))
-    addLog(`${hero.name} enters the dungeon.`)
+    addLog(`*${hero.name} steps into the dungeon, torch held high.*`)
   }, [addLog])
 
   useEffect(() => {
@@ -201,14 +202,14 @@ function App() {
         encounter: null,
         trap: newTrap,
       }))
-      addLog(`${hero.name} moves ${dir}`)
+      addLog(`${hero.name} advances ${dir}, eyes on the shadows.`)
       if (newBoard[r][c].goblin) {
-        addLog(`Encountered ${newBoard[r][c].goblin.name}`)
-        if (revealedGoblin) addLog('Ambushed and lost 1 hp')
+        addLog(`A ${newBoard[r][c].goblin.name} leaps from the darkness!`)
+        if (revealedGoblin) addLog('The ambush wounds you for 1 HP.')
       }
       if (newTrap) {
         const t = newTrap.trap
-        addLog(`Found trap: ${t.id} (difficulty ${t.difficulty})`)
+        addLog(`You spot a ${t.id} trap—difficulty ${t.difficulty}.`)
       }
     },
     [state, addLog]
@@ -250,7 +251,7 @@ function App() {
         },
       }))
       addLog(
-        `${hero.name} attacks ${tile.goblin.name}${dist > 0 ? ' from afar' : ''}`,
+        `${hero.name} strikes at ${tile.goblin.name}${dist > 0 ? ' from afar' : ''}!`,
       )
     },
     [state, addLog],
@@ -417,6 +418,7 @@ function App() {
           <TorchMat step={state.torch} />
         </div>
         <div className="side">
+        <EventLog log={eventLog.slice(-3)} className="narrative-log" />
         <HeroPanel hero={state.hero} damaged={heroDamaged} />
         {state.hero && (
           <div className="hero-items">

--- a/src/components/EventLog.jsx
+++ b/src/components/EventLog.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import './EventLog.scss'
 
-function EventLog({ log }) {
+function EventLog({ log, className = '' }) {
   return (
-    <div className="event-log">
+    <div className={`event-log${className ? ` ${className}` : ''}`}>
       {log.map((entry, idx) => (
         <div key={idx} className="log-entry">
           {entry}

--- a/src/components/EventLog.scss
+++ b/src/components/EventLog.scss
@@ -12,3 +12,9 @@
 .log-entry + .log-entry {
   margin-top: 0.25rem;
 }
+
+.narrative-log {
+  margin-bottom: 0.5rem;
+  max-height: 6rem;
+  font-style: italic;
+}

--- a/src/hooks/useEncounterHandlers.js
+++ b/src/hooks/useEncounterHandlers.js
@@ -9,7 +9,7 @@ export default function useEncounterHandlers(setState, addLog) {
       const rewardParts = []
       if (rewards.ap) rewardParts.push(`${rewards.ap} ap`)
       if (rewards.hp) rewardParts.push(`${rewards.hp} hp`)
-      addLog(`Unused dice reward: ${rewardParts.join(' and ')}.`)
+      addLog(`The unused dice grant ${rewardParts.join(' and ')}.`)
       setState(prev => {
         const hero = prev.hero
         if (!hero) return prev
@@ -27,7 +27,7 @@ export default function useEncounterHandlers(setState, addLog) {
   const applySkillCost = useCallback(
     (cost, title) => {
       if (!cost) return
-      addLog(`Used ${title} (-${cost} AP).`)
+      addLog(`${title} invoked, costing ${cost} AP.`)
       setState(prev => {
         const hero = prev.hero
         if (!hero) return prev
@@ -113,11 +113,11 @@ export default function useEncounterHandlers(setState, addLog) {
             y: Math.random() * 40 - 20,
           }
           newEncounter = null
-          msg = 'Fled successfully.'
+          msg = 'You escape into the corridor.'
         } else {
           const damage = Math.max(1, encounter.goblin.attack - hero.defence)
           newHero.hp = hero.hp - damage
-          msg = `Failed to flee and took ${damage} damage.`
+          msg = `The goblin blocks your path, dealing ${damage} damage!`
         }
         return { ...prev, board: newBoard, hero: newHero, encounter: newEncounter }
       })
@@ -148,7 +148,7 @@ export default function useEncounterHandlers(setState, addLog) {
         let discard = null
         if (!evaded) {
           newHero.hp = hero.hp - tile.trap.damage
-          messageParts.push(`Hit by trap for ${tile.trap.damage} damage.`)
+          messageParts.push(`The trap snaps shut, dealing ${tile.trap.damage} damage!`)
         } else {
           newHero.ap = Math.min(hero.ap + evasionRewards.ap, hero.maxAp)
           newHero.hp = Math.min(newHero.hp + evasionRewards.hp, hero.maxHp)
@@ -156,7 +156,9 @@ export default function useEncounterHandlers(setState, addLog) {
           if (evasionRewards.ap) rParts.push(`${evasionRewards.ap} ap`)
           if (evasionRewards.hp) rParts.push(`${evasionRewards.hp} hp`)
           messageParts.push(
-            rParts.length ? `Evaded trap and gained ${rParts.join(' and ')}.` : 'Evaded trap.',
+            rParts.length
+              ? `You deftly evade the trap and gain ${rParts.join(' and ')}.`
+              : 'You nimbly evade the trap.',
           )
         }
         if (disarm !== undefined) {
@@ -171,10 +173,10 @@ export default function useEncounterHandlers(setState, addLog) {
             if (tile.trap.reward) rewardMsg.push(`${tile.trap.reward} hp`)
             if (rewards.ap) rewardMsg.push(`${rewards.ap} ap`)
             if (rewards.hp) rewardMsg.push(`${rewards.hp} bonus hp`)
-            messageParts.push(`Disarmed trap and gained ${rewardMsg.join(' and ')}.`)
+            messageParts.push(`You disarm the trap and gain ${rewardMsg.join(' and ')}.`)
           } else {
             newHero.hp = newHero.hp - tile.trap.damage
-            messageParts.push(`Failed to disarm and took ${tile.trap.damage} damage.`)
+            messageParts.push(`You fail to disarm it and suffer ${tile.trap.damage} damage!`)
           }
         }
         return { ...prev, board: newBoard, hero: newHero, trap: null, reward, discard }
@@ -191,7 +193,7 @@ export default function useEncounterHandlers(setState, addLog) {
 
   const handleRewardConfirm = useCallback(
     () => {
-      let msg = 'Collected reward'
+      let msg = 'You gather the spoils.'
       setState(prev => {
         if (!prev.reward) return prev
         let discard = null
@@ -208,7 +210,7 @@ export default function useEncounterHandlers(setState, addLog) {
   const handleDiscardConfirm = useCallback(
     items => {
       setState(prev => ({ ...prev, hero: { ...prev.hero, weapons: items }, discard: null }))
-      addLog('Chose items to keep')
+      addLog('You decide which gear to keep.')
     },
     [addLog, setState],
   )


### PR DESCRIPTION
## Summary
- display last 3 log messages above the hero card
- support optional className prop on `EventLog`
- style narrative log
- write more thematic log messages
- document new feature in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f02dd2c7c832690d4ce07600e92fa