### PR TITLE
Show goblin cards above board on hover

### DIFF
--- a/src/components/GoblinToken.jsx
+++ b/src/components/GoblinToken.jsx
@@ -1,14 +1,37 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import './GoblinToken.scss'
 import GoblinCard from './GoblinCard'
 
 function GoblinToken({ goblin }) {
   const [hover, setHover] = useState(false)
+  const [pos, setPos] = useState({ top: 0, left: 0 })
+  const tokenRef = useRef(null)
+  const overlayRef = useRef(null)
+
+  const showCard = () => {
+    const rect = tokenRef.current.getBoundingClientRect()
+    setPos({ top: rect.top + window.scrollY, left: rect.right + 8 + window.scrollX })
+    setHover(true)
+  }
+
+  const hideCard = e => {
+    if (overlayRef.current && overlayRef.current.contains(e.relatedTarget)) return
+    setHover(false)
+  }
+
+  const hideFromOverlay = e => {
+    if (tokenRef.current && tokenRef.current.contains(e.relatedTarget)) return
+    setHover(false)
+  }
+
   return (
-    <div
+    <>
+      <div
       className="goblin-token"
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
+      ref={tokenRef}
+      onMouseEnter={showCard}
+      onMouseLeave={hideCard}
     >
       <img className="token-image" src={goblin.image} alt={goblin.name} />
       <div className="hp-hearts">
@@ -22,12 +45,21 @@ function GoblinToken({ goblin }) {
           <span>{goblin.defence}</span>
         </div>
       )}
-      {hover && (
-        <div className="hover-card">
-          <GoblinCard goblin={goblin} />
-        </div>
-      )}
-    </div>
+      </div>
+      {hover &&
+        createPortal(
+          <div
+            className="hover-card-overlay"
+            ref={overlayRef}
+            onMouseLeave={hideFromOverlay}
+            onMouseEnter={() => setHover(true)}
+            style={{ top: pos.top, left: pos.left }}
+          >
+            <GoblinCard goblin={goblin} />
+          </div>,
+          document.body
+        )}
+    </>
   )
 }
 

--- a/src/components/GoblinToken.scss
+++ b/src/components/GoblinToken.scss
@@ -6,10 +6,6 @@
   position: relative;
   overflow: visible;
 
-  &:hover .hover-card {
-    display: block;
-  }
-
   .token-image {
     width: 100%;
     height: 100%;
@@ -58,11 +54,9 @@
     }
   }
 
-  .hover-card {
-    display: none;
-    position: absolute;
-    left: calc(100% + 0.5rem);
-    top: 0;
-    z-index: 15;
-  }
+}
+
+.hover-card-overlay {
+  position: absolute;
+  z-index: 60;
 }


### PR DESCRIPTION
## Summary
- render hovered goblin card in a portal so it isn't clipped by columns
- add overlay styling for the portal position

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68518b902bb483269fc1eabbacb8161e