### PR TITLE
Implement torch step 4 goblin rush

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ A horizontal torch bar below the dungeon board counts turns. The torch starts at
 step 0 and drops one step every time you end your turn. A burning torch icon
 marks the current position on the track. Reaching step 20 opens a Game Over
 modal announcing defeat.
-Each end turn logs a short message as the torch advances so you can follow the
-countdown in the narrative feed.
+Each end turn logs a short message as the torch advances so you can follow the countdown in the narrative feed. When the torch reaches step 4 all discovered monsters march toward the hero using their movement points in the order they appeared.
 
 ### Styling with SCSS
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import {
   opposite,
   distanceToTarget,
   distanceMagic,
+  moveGoblinsTowardsHero,
 } from './boardUtils'
 import {
   BOARD_SIZE,
@@ -125,6 +126,13 @@ function App() {
     const base = HERO_TYPES[state.hero.type]
     const newTorch = Math.min(state.torch + 1, 20)
     const gameOver = state.gameOver || newTorch >= 20
+    let board = state.board
+    let positions = state.discoveredGoblins
+    if (newTorch === 4) {
+      const moved = moveGoblinsTowardsHero(state.board, state.hero, state.discoveredGoblins)
+      board = moved.board
+      positions = moved.positions
+    }
     setState(prev => ({
       ...prev,
       hero: {
@@ -133,11 +141,14 @@ function App() {
         ap: prev.hero.maxAp,
         heroAction: prev.hero.maxHeroAction,
       },
+      board,
+      discoveredGoblins: positions,
       torch: newTorch,
       gameOver,
     }))
     addLog(`${state.hero.name} pauses to regroup.`)
     addLog(`Torch advances to ${newTorch}/20.`)
+    if (newTorch === 4) addLog('The goblins surge forward!')
   }, [state, addLog])
 
   const resetGame = useCallback(() => {

--- a/src/goblinData.js
+++ b/src/goblinData.js
@@ -2,6 +2,7 @@ export const GOBLIN_TYPES = {
   knife: {
     name: 'Knife Goblin',
     hp: 1,
+    movement: 2,
     attack: 1,
     attackType: 'melee',
     attacks: [
@@ -15,6 +16,7 @@ export const GOBLIN_TYPES = {
   archer: {
     name: 'Archer Goblin',
     hp: 1,
+    movement: 2,
     attack: 2,
     attackType: 'range',
     range: 3,
@@ -29,6 +31,7 @@ export const GOBLIN_TYPES = {
   mage: {
     name: 'Mage Goblin',
     hp: 1,
+    movement: 2,
     attack: 6,
     attackType: 'magic',
     range: 5,
@@ -43,6 +46,7 @@ export const GOBLIN_TYPES = {
   king: {
     name: 'Goblin King',
     hp: 1,
+    movement: 3,
     attack: 5,
     attackType: 'melee',
     attacks: [


### PR DESCRIPTION
## Summary
- add movement stat to goblins
- implement pathfinding helpers and goblin rush logic
- trigger a mass goblin advance when the torch reaches step 4
- document the rule in the README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851902a70fc832683611d2d8caf3c3b