### PR TITLE
Add goblin movement animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ npm test
 - Actions are recorded in an event log viewable from the **Dev** button, and the
   latest three entries are shown above the hero card as a narrative feed.
 - Hovering a goblin token reveals its full card for quick reference.
+- Goblins now slide across the board when they advance on the hero.
+- Room tiles display a goblin icon image instead of a letter.
 
 The hero panel now displays these attributes along with a portrait image for the selected hero. Lost HP is shown using the same heart icon tinted black via CSS so you can quickly gauge your health. Dice stats are represented by repeating dice icons rather than numbers.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm test
   latest three entries are shown above the hero card as a narrative feed.
 - Hovering a goblin token reveals its full card for quick reference.
 - Goblins now slide across the board when they advance on the hero.
-- Room tiles display a goblin icon image instead of a letter.
+- Goblin icons now overlay rooms as movable tokens.
 
 The hero panel now displays these attributes along with a portrait image for the selected hero. Lost HP is shown using the same heart icon tinted black via CSS so you can quickly gauge your health. Dice stats are represented by repeating dice icons rather than numbers.
 

--- a/src/App.css
+++ b/src/App.css
@@ -76,6 +76,14 @@
   animation: goblin-move 0.8s forwards;
 }
 
+.goblin-move {
+  position: absolute;
+  width: calc(100% / 7);
+  height: calc(100% / 7);
+  pointer-events: none;
+  animation: goblin-slide 0.4s forwards;
+}
+
 @keyframes goblin-spin {
   0% {
     transform: scale(0) rotate(0) rotateY(0);
@@ -94,6 +102,15 @@
   }
   to {
     transform: translate(-110%, 0);
+  }
+}
+
+@keyframes goblin-slide {
+  from {
+    transform: translate(0, 0);
+  }
+  to {
+    transform: translate(var(--dx), var(--dy));
   }
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import { HERO_TYPES } from './heroData'
 import { GOBLIN_TYPES, randomGoblinType } from './goblinData'
 import GoblinCard from './components/GoblinCard'
 import GoblinToken from './components/GoblinToken'
+import GoblinIcon from './components/GoblinIcon'
 import {
   getRangedTargets,
   getMagicTargets,
@@ -459,6 +460,17 @@ function App() {
               )
             })
           )}
+          {state.discoveredGoblins.map(pos => {
+            const goblin = state.board[pos.row][pos.col].goblin
+            return goblin ? (
+              <GoblinIcon
+                key={`g-${pos.row}-${pos.col}`}
+                row={pos.row}
+                col={pos.col}
+                icon={goblin.icon}
+              />
+            ) : null
+          })}
           {state.hero && (
             <div
               className={`hero-overlay${heroDamaged ? ' shake' : ''}`}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,7 @@ function App() {
   const [actionPrompt, setActionPrompt] = useState(null)
   const [revealGoblin, setRevealGoblin] = useState(null)
   const [revealPhase, setRevealPhase] = useState('spin')
+  const [goblinMoves, setGoblinMoves] = useState([])
   const prevHpRef = useRef(state.hero ? state.hero.hp : null)
 
   const addLog = useCallback(msg => {
@@ -121,6 +122,12 @@ function App() {
     }
   }, [revealGoblin, setState])
 
+  useEffect(() => {
+    if (goblinMoves.length === 0) return
+    const t = setTimeout(() => setGoblinMoves([]), 400)
+    return () => clearTimeout(t)
+  }, [goblinMoves])
+
   const endTurn = useCallback(() => {
     if (!state.hero) return
     const base = HERO_TYPES[state.hero.type]
@@ -132,6 +139,7 @@ function App() {
       const moved = moveGoblinsTowardsHero(state.board, state.hero, state.discoveredGoblins)
       board = moved.board
       positions = moved.positions
+      setGoblinMoves(moved.moves)
     }
     setState(prev => ({
       ...prev,
@@ -463,6 +471,20 @@ function App() {
               <Hero hero={state.hero} damaged={heroDamaged} />
             </div>
           )}
+          {goblinMoves.map((m, idx) => (
+            <img
+              key={idx}
+              className="goblin-move"
+              src={m.goblin.icon}
+              alt="goblin"
+              style={{
+                top: `calc(${m.from.row} * (100% / ${BOARD_SIZE}))`,
+                left: `calc(${m.from.col} * (100% / ${BOARD_SIZE}))`,
+                '--dx': `${(m.to.col - m.from.col) * 100}%`,
+                '--dy': `${(m.to.row - m.from.row) * 100}%`,
+              }}
+            />
+          ))}
           {revealGoblin && (
             <div
               className={`goblin-reveal ${revealPhase}`}

--- a/src/boardUtils.js
+++ b/src/boardUtils.js
@@ -160,10 +160,11 @@ export function nextStepTowards(board, fromRow, fromCol, toRow, toCol) {
 export function moveGoblinsTowardsHero(board, hero, goblinPositions) {
   const copy = board.map(row => row.map(t => ({ ...t })));
   const newPositions = goblinPositions.map(p => ({ ...p }));
+  const moves = [];
   goblinPositions.forEach((pos, idx) => {
     const tile = copy[pos.row][pos.col];
-      const gob = tile.goblin;
-      if (!gob || gob.hp <= 0) return;
+    const gob = tile.goblin;
+    if (!gob || gob.hp <= 0) return;
     let r = pos.row;
     let c = pos.col;
     for (let step = 0; step < (gob.movement || 1); step++) {
@@ -178,6 +179,9 @@ export function moveGoblinsTowardsHero(board, hero, goblinPositions) {
       if (r === hero.row && c === hero.col) break;
     }
     newPositions[idx] = { row: r, col: c };
+    if (r !== pos.row || c !== pos.col) {
+      moves.push({ goblin: gob, from: { ...pos }, to: { row: r, col: c } });
+    }
   });
-  return { board: copy, positions: newPositions };
+  return { board: copy, positions: newPositions, moves };
 }

--- a/src/components/GoblinCard.scss
+++ b/src/components/GoblinCard.scss
@@ -187,7 +187,7 @@
     background: rgba(255, 255, 255, 0.7);
     color: #000;
     padding: 0.25rem;
-    font-size: 0.7rem;
+    font-size: 0.6rem;
     text-align: left;
   }
 }

--- a/src/components/GoblinIcon.jsx
+++ b/src/components/GoblinIcon.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import './GoblinIcon.scss'
+
+function GoblinIcon({ row, col, icon }) {
+  return (
+    <div
+      className="goblin-overlay"
+      style={{ transform: `translate(${col * 100}%, ${row * 100}%)` }}
+    >
+      <img className="goblin-icon" src={icon} alt="goblin" />
+    </div>
+  )
+}
+
+export default GoblinIcon

--- a/src/components/GoblinIcon.scss
+++ b/src/components/GoblinIcon.scss
@@ -1,0 +1,16 @@
+.goblin-overlay {
+  position: absolute;
+  width: calc(100% / 7);
+  height: calc(100% / 7);
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+}
+
+.goblin-icon {
+  width: 30px;
+  height: 30px;
+}

--- a/src/components/RoomTile.jsx
+++ b/src/components/RoomTile.jsx
@@ -12,9 +12,9 @@ function RoomTile({ tile, move, attack, attackDisabled = false, highlight, disab
       title={
         tile.revealed
           ? tile.roomId +
-            (tile.trap && !tile.trapResolved
-              ? ` - ${EVASION_RULE} Difficulty ${tile.trap.difficulty}. ${DISARM_RULE}`
-              : '')
+          (tile.trap && !tile.trapResolved
+            ? ` - ${EVASION_RULE} Difficulty ${tile.trap.difficulty}. ${DISARM_RULE}`
+            : '')
           : undefined
       }
     >
@@ -31,7 +31,7 @@ function RoomTile({ tile, move, attack, attackDisabled = false, highlight, disab
       )}
       {tile.revealed && tile.goblin && (
         <div className="goblin-container">
-          <img className="goblin-icon" src={tile.goblin.icon} alt="goblin" />
+          <img className="goblin-icon" src='/icon/icon-goblin.png' alt="goblin" />
         </div>
       )}
       {(move || attack) && (

--- a/src/components/RoomTile.jsx
+++ b/src/components/RoomTile.jsx
@@ -12,11 +12,6 @@ function RoomTile({ tile, move, attack, attackDisabled = false, highlight, disab
       title={
         tile.revealed
           ? tile.roomId +
-          (tile.trap && !tile.trapResolved
-            ? ` - ${EVASION_RULE} Difficulty ${tile.trap.difficulty}. ${DISARM_RULE}`
-            : '')
-          : undefined
-      }
     >
       {!tile.revealed && <div className="card-back" />}
       {tile.revealed && (

--- a/src/components/RoomTile.jsx
+++ b/src/components/RoomTile.jsx
@@ -31,7 +31,7 @@ function RoomTile({ tile, move, attack, attackDisabled = false, highlight, disab
       )}
       {tile.revealed && tile.goblin && (
         <div className="goblin-container">
-          <span className="goblin-icon">{tile.goblin.icon}</span>
+          <img className="goblin-icon" src={tile.goblin.icon} alt="goblin" />
         </div>
       )}
       {(move || attack) && (

--- a/src/components/RoomTile.scss
+++ b/src/components/RoomTile.scss
@@ -118,21 +118,6 @@
     }
   }
 
-  .goblin-container {
-    position: absolute;
-    bottom: 0px;
-    left: 0;
-    width: 2rem;
-    aspect-ratio: 1 / 1;
-  }
-
-  .goblin-icon {
-    position: relative;
-    z-index: 1;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
 
 
   .action-buttons {

--- a/src/components/RoomTile.scss
+++ b/src/components/RoomTile.scss
@@ -120,11 +120,10 @@
 
   .goblin-container {
     position: absolute;
-    bottom: 2px;
-    left: 2px;
-    font-size: 0.7rem;
-    width: 0.7rem;
-    height: 0.7rem;
+    bottom: 0px;
+    left: 0;
+    width: 2rem;
+    aspect-ratio: 1 / 1;
   }
 
   .goblin-icon {

--- a/src/components/RoomTile.scss
+++ b/src/components/RoomTile.scss
@@ -123,11 +123,16 @@
     bottom: 2px;
     left: 2px;
     font-size: 0.7rem;
+    width: 0.7rem;
+    height: 0.7rem;
   }
 
   .goblin-icon {
     position: relative;
     z-index: 1;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
   }
 
 

--- a/src/goblinData.js
+++ b/src/goblinData.js
@@ -10,7 +10,7 @@ export const GOBLIN_TYPES = {
     ],
     extra: 1,
     defence: 5,
-    icon: 'K',
+    icon: '/icon/icon-goblin.png',
     image: '/goblin/stabby-goblin.webp',
   },
   archer: {
@@ -25,7 +25,7 @@ export const GOBLIN_TYPES = {
       { type: 'range', attack: 2, range: 3 },
     ],
     defence: 7,
-    icon: 'A',
+    icon: '/icon/icon-goblin.png',
     image: '/goblin/shooty-goblin.webp',
   },
   mage: {
@@ -40,7 +40,7 @@ export const GOBLIN_TYPES = {
       { type: 'magic', attack: 6, range: 5 },
     ],
     defence: 4,
-    icon: 'M',
+    icon: '/icon/icon-goblin.png',
     image: '/goblin/shaman-goblin.webp',
   },
   king: {
@@ -54,7 +54,7 @@ export const GOBLIN_TYPES = {
     ],
     extra: 2,
     defence: 10,
-    icon: 'G',
+    icon: '/icon/icon-goblin.png',
     image: '/goblin/boss-goblin.webp',
   },
 };


### PR DESCRIPTION
## Summary
- animate goblins moving toward the hero
- display goblin icons as images instead of letters
- tweak goblin icon styles
- document the new animation and icons in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851957886b0832693e941ea08c36c07