### PR TITLE
Add goblin overlay component

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npm test
 - Actions are recorded in an event log viewable from the **Dev** button, and the
   latest three entries are shown above the hero card as a narrative feed.
 - Hovering a goblin token reveals its full card for quick reference.
+- Goblin icons now appear in random corners of rooms with a slight tilt.
 
 The hero panel now displays these attributes along with a portrait image for the selected hero. Lost HP is shown using the same heart icon tinted black via CSS so you can quickly gauge your health. Dice stats are represented by repeating dice icons rather than numbers.
 

--- a/src/App.css
+++ b/src/App.css
@@ -27,6 +27,19 @@
   transition: transform 0.2s;
 }
 
+.goblin-overlay {
+  position: absolute;
+  width: calc(100% / 7);
+  height: calc(100% / 7);
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+  transition: transform 0.2s;
+}
+
 .main {
   display: grid;
   grid-template-columns: 3fr 4fr 4fr;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -187,7 +187,18 @@ function App() {
         let goblin = null
         if (room.goblin) {
           const typeKey = room.goblin === 'king' ? 'king' : randomGoblinType()
-          goblin = { ...GOBLIN_TYPES[typeKey], type: typeKey }
+          const corners = [
+            { x: -35, y: -35 },
+            { x: 35, y: -35 },
+            { x: -35, y: 35 },
+            { x: 35, y: 35 },
+          ]
+          goblin = {
+            ...GOBLIN_TYPES[typeKey],
+            type: typeKey,
+            offset: corners[Math.floor(Math.random() * corners.length)],
+            angle: Math.random() * 30 - 15,
+          }
           revealedGoblin = true
         }
 
@@ -458,7 +469,11 @@ function App() {
               <div
                 key={`gob-${g.row}-${g.col}`}
                 className="goblin-overlay"
-                style={{ transform: `translate(${g.col * 100}%, ${g.row * 100}%)` }}
+                style={{
+                  transform: `translate(${g.col * 100 + (gob.offset?.x ?? 0)}%, ${
+                    g.row * 100 + (gob.offset?.y ?? 0)
+                  }%) rotate(${gob.angle ?? 0}deg)`,
+                }}
               >
                 <Goblin goblin={gob} />
               </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import { HERO_TYPES } from './heroData'
 import { GOBLIN_TYPES, randomGoblinType } from './goblinData'
 import GoblinCard from './components/GoblinCard'
 import GoblinToken from './components/GoblinToken'
+import Goblin from './components/Goblin'
 import {
   getRangedTargets,
   getMagicTargets,
@@ -451,6 +452,18 @@ function App() {
               )
             })
           )}
+          {state.discoveredGoblins.map(g => {
+            const gob = state.board[g.row][g.col].goblin
+            return gob ? (
+              <div
+                key={`gob-${g.row}-${g.col}`}
+                className="goblin-overlay"
+                style={{ transform: `translate(${g.col * 100}%, ${g.row * 100}%)` }}
+              >
+                <Goblin goblin={gob} />
+              </div>
+            ) : null
+          })}
           {state.hero && (
             <div
               className={`hero-overlay${heroDamaged ? ' shake' : ''}`}

--- a/src/components/Goblin.jsx
+++ b/src/components/Goblin.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import './Goblin.scss'
+
+function Goblin({ goblin, damaged }) {
+  return <div className={`goblin${damaged ? ' shake' : ''}`}>{goblin.icon}</div>
+}
+
+export default Goblin

--- a/src/components/Goblin.jsx
+++ b/src/components/Goblin.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import './Goblin.scss';
+function Goblin({ goblin, damaged, style }) {
+    <div className={`goblin${damaged ? ' shake' : ''}`} style={style}>
 
 function Goblin({ goblin, damaged }) {
   return (

--- a/src/components/Goblin.jsx
+++ b/src/components/Goblin.jsx
@@ -2,7 +2,11 @@ import React from 'react'
 import './Goblin.scss'
 
 function Goblin({ goblin, damaged }) {
-  return <div className={`goblin${damaged ? ' shake' : ''}`}>{goblin.icon}</div>
+  return (
+    <div className={`goblin${damaged ? ' shake' : ''}`}>
+      <img src={goblin.image} alt={goblin.name} />
+    </div>
+  )
 }
 
 export default Goblin

--- a/src/components/Goblin.jsx
+++ b/src/components/Goblin.jsx
@@ -1,9 +1,8 @@
-function Goblin({ goblin, damaged, style }) {
-    <div className={`goblin${damaged ? ' shake' : ''}`} style={style}>
+import './Goblin.scss';
 
-function Goblin({ goblin, damaged }) {
+function Goblin({ goblin, damaged, style }) {
   return (
-    <div className={`goblin${damaged ? ' shake' : ''}`}>
+    <div className={`goblin${damaged ? ' shake' : ''}`} style={style}>
       <img src='/icon/icon-goblin.png' alt={goblin.name} />
     </div>
   );

--- a/src/components/Goblin.jsx
+++ b/src/components/Goblin.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import './Goblin.scss'
+import React from 'react';
+import './Goblin.scss';
 
 function Goblin({ goblin, damaged }) {
   return (
     <div className={`goblin${damaged ? ' shake' : ''}`}>
-      <img src={goblin.image} alt={goblin.name} />
+      <img src='/icon/icon-goblin.png' alt={goblin.name} />
     </div>
-  )
+  );
 }
 
-export default Goblin
+export default Goblin;

--- a/src/components/Goblin.scss
+++ b/src/components/Goblin.scss
@@ -1,7 +1,4 @@
-
 .goblin {
-  background-color: darkgreen;
-  color: white;
   width: 30px;
   height: 30px;
   display: flex;
@@ -22,9 +19,23 @@
 }
 
 @keyframes shake {
-  0% { transform: translate(0); }
-  25% { transform: translate(-3px); }
-  50% { transform: translate(3px); }
-  75% { transform: translate(-3px); }
-  100% { transform: translate(0); }
+  0% {
+    transform: translate(0);
+  }
+
+  25% {
+    transform: translate(-3px);
+  }
+
+  50% {
+    transform: translate(3px);
+  }
+
+  75% {
+    transform: translate(-3px);
+  }
+
+  100% {
+    transform: translate(0);
+  }
 }

--- a/src/components/Goblin.scss
+++ b/src/components/Goblin.scss
@@ -1,3 +1,4 @@
+
 .goblin {
   background-color: darkgreen;
   color: white;
@@ -7,6 +8,13 @@
   justify-content: center;
   align-items: center;
   border-radius: 4px;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 
   &.shake {
     animation: shake 0.3s;

--- a/src/components/Goblin.scss
+++ b/src/components/Goblin.scss
@@ -1,0 +1,22 @@
+.goblin {
+  background-color: darkgreen;
+  color: white;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+
+  &.shake {
+    animation: shake 0.3s;
+  }
+}
+
+@keyframes shake {
+  0% { transform: translate(0); }
+  25% { transform: translate(-3px); }
+  50% { transform: translate(3px); }
+  75% { transform: translate(-3px); }
+  100% { transform: translate(0); }
+}

--- a/src/components/RoomTile.jsx
+++ b/src/components/RoomTile.jsx
@@ -29,11 +29,6 @@ function RoomTile({ tile, move, attack, attackDisabled = false, highlight, disab
           )}
         </div>
       )}
-      {tile.revealed && tile.goblin && (
-        <div className="goblin-container">
-          <span className="goblin-icon">{tile.goblin.icon}</span>
-        </div>
-      )}
       {(move || attack) && (
         <div className="action-buttons">
           {move && <button onClick={onMove}>Move</button>}

--- a/src/components/RoomTile.scss
+++ b/src/components/RoomTile.scss
@@ -118,18 +118,6 @@
     }
   }
 
-  .goblin-container {
-    position: absolute;
-    bottom: 2px;
-    left: 2px;
-    font-size: 0.7rem;
-  }
-
-  .goblin-icon {
-    position: relative;
-    z-index: 1;
-  }
-
 
   .action-buttons {
     display: none;

--- a/src/gameSetup.js
+++ b/src/gameSetup.js
@@ -39,6 +39,20 @@ export function loadState() {
           row.forEach(tile => {
             if (!tile.paths) tile.paths = { up: false, down: false, left: false, right: false }
             if (!('goblin' in tile)) tile.goblin = null
+            if (tile.goblin) {
+              if (!tile.goblin.offset) {
+                const corners = [
+                  { x: -35, y: -35 },
+                  { x: 35, y: -35 },
+                  { x: -35, y: 35 },
+                  { x: 35, y: 35 },
+                ]
+                tile.goblin.offset = corners[Math.floor(Math.random() * corners.length)]
+              }
+              if (tile.goblin.angle == null) {
+                tile.goblin.angle = Math.random() * 30 - 15
+              }
+            }
             if (!('trap' in tile)) tile.trap = null
             if (tile.trap && typeof tile.trap === 'string') {
               tile.trap = { ...TRAP_TYPES[tile.trap], id: tile.trap }


### PR DESCRIPTION
## Summary
- create `Goblin` component analogous to Hero icon
- remove goblin markup from `RoomTile`
- add overlay positioning for goblins on the board
- style goblin overlay similar to hero overlay

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68519fe80d288326b3fe62c75ab3fcdc