### PR TITLE
Add sequential monster movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A horizontal torch bar below the dungeon board counts turns. The torch starts at
 step 0 and drops one step every time you end your turn. A burning torch icon
 marks the current position on the track. Reaching step 20 opens a Game Over
 modal announcing defeat.
-Each end turn logs a short message as the torch advances so you can follow the countdown in the narrative feed. When the torch reaches step 4 every discovered monster now advances one room at a time. Each move is logged so you can track how the dungeon closes in around the hero.
+Each end turn logs a short message as the torch advances so you can follow the countdown in the narrative feed. When the torch reaches step 4 every discovered monster now advances one room at a time with a one second pause between each move. Every step is logged so you can track how the dungeon closes in around the hero.
 
 ### Styling with SCSS
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A horizontal torch bar below the dungeon board counts turns. The torch starts at
 step 0 and drops one step every time you end your turn. A burning torch icon
 marks the current position on the track. Reaching step 20 opens a Game Over
 modal announcing defeat.
-Each end turn logs a short message as the torch advances so you can follow the countdown in the narrative feed. When the torch reaches step 4 all discovered monsters march toward the hero using their movement points in the order they appeared.
+Each end turn logs a short message as the torch advances so you can follow the countdown in the narrative feed. When the torch reaches step 4 every discovered monster now advances one room at a time. Each move is logged so you can track how the dungeon closes in around the hero.
 
 ### Styling with SCSS
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -129,10 +129,16 @@ function App() {
     const gameOver = state.gameOver || newTorch >= 20
     let board = state.board
     let positions = state.discoveredGoblins
+    let moveLogs = []
     if (newTorch === 4) {
-      const moved = moveGoblinsTowardsHero(state.board, state.hero, state.discoveredGoblins)
+      const moved = moveGoblinsTowardsHero(
+        state.board,
+        state.hero,
+        state.discoveredGoblins,
+      )
       board = moved.board
       positions = moved.positions
+      moveLogs = moved.logs
     }
     setState(prev => ({
       ...prev,
@@ -149,7 +155,10 @@ function App() {
     }))
     addLog(`${state.hero.name} pauses to regroup.`)
     addLog(`Torch advances to ${newTorch}/20.`)
-    if (newTorch === 4) addLog('The goblins surge forward!')
+    if (newTorch === 4) {
+      addLog('The goblins surge forward!')
+      moveLogs.forEach(msg => addLog(msg))
+    }
   }, [state, addLog])
 
   const resetGame = useCallback(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,24 +122,27 @@ function App() {
     }
   }, [revealGoblin, setState])
 
+  const animateGoblinSteps = useCallback(
+    async steps => {
+      for (const step of steps) {
+        await new Promise(res => setTimeout(res, 1000))
+        setState(prev => ({
+          ...prev,
+          board: step.board,
+          discoveredGoblins: step.positions,
+        }))
+        step.logs.forEach(msg => addLog(msg))
+      }
+    },
+    [addLog],
+  )
+
   const endTurn = useCallback(() => {
     if (!state.hero) return
     const base = HERO_TYPES[state.hero.type]
     const newTorch = Math.min(state.torch + 1, 20)
     const gameOver = state.gameOver || newTorch >= 20
-    let board = state.board
-    let positions = state.discoveredGoblins
-    let moveLogs = []
-    if (newTorch === 4) {
-      const moved = moveGoblinsTowardsHero(
-        state.board,
-        state.hero,
-        state.discoveredGoblins,
-      )
-      board = moved.board
-      positions = moved.positions
-      moveLogs = moved.logs
-    }
+
     setState(prev => ({
       ...prev,
       hero: {
@@ -148,8 +151,6 @@ function App() {
         ap: prev.hero.maxAp,
         heroAction: prev.hero.maxHeroAction,
       },
-      board,
-      discoveredGoblins: positions,
       torch: newTorch,
       gameOver,
     }))
@@ -157,9 +158,14 @@ function App() {
     addLog(`Torch advances to ${newTorch}/20.`)
     if (newTorch === 4) {
       addLog('The goblins surge forward!')
-      moveLogs.forEach(msg => addLog(msg))
+      const { steps } = moveGoblinsTowardsHero(
+        state.board,
+        state.hero,
+        state.discoveredGoblins,
+      )
+      animateGoblinSteps(steps)
     }
-  }, [state, addLog])
+  }, [state, addLog, animateGoblinSteps])
 
   const resetGame = useCallback(() => {
     localStorage.removeItem('dungeon-state')

--- a/src/boardUtils.js
+++ b/src/boardUtils.js
@@ -157,12 +157,11 @@ export function nextStepTowards(board, fromRow, fromCol, toRow, toCol) {
   return null;
 }
 
-export function moveGoblinsTowardsHero(board, hero, goblinPositions) {
+export function getGoblinMoveSteps(board, hero, goblinPositions) {
   const copy = board.map(row => row.map(t => ({ ...t })))
   const newPositions = goblinPositions.map(p => ({ ...p }))
-  const logs = []
+  const steps = []
 
-  // Determine the maximum movement across all goblins
   const maxMove = Math.max(
     0,
     ...goblinPositions.map(pos => {
@@ -172,6 +171,8 @@ export function moveGoblinsTowardsHero(board, hero, goblinPositions) {
   )
 
   for (let step = 0; step < maxMove; step++) {
+    const logs = []
+    let moved = false
     for (let idx = 0; idx < goblinPositions.length; idx++) {
       const pos = newPositions[idx]
       const tile = copy[pos.row][pos.col]
@@ -188,8 +189,24 @@ export function moveGoblinsTowardsHero(board, hero, goblinPositions) {
       copy[pos.row][pos.col] = { ...tile, goblin: null }
       newPositions[idx] = { row: nr, col: nc }
       logs.push(`${gob.name} moves toward the hero.`)
+      moved = true
+    }
+    if (moved) {
+      const stepBoard = copy.map(row => row.map(t => ({ ...t })))
+      const stepPositions = newPositions.map(p => ({ ...p }))
+      steps.push({ board: stepBoard, positions: stepPositions, logs })
     }
   }
 
-  return { board: copy, positions: newPositions, logs }
+  return { board: copy, positions: newPositions, steps }
+}
+
+export function moveGoblinsTowardsHero(board, hero, goblinPositions) {
+  const { board: b, positions, steps } = getGoblinMoveSteps(
+    board,
+    hero,
+    goblinPositions,
+  )
+  const logs = steps.flatMap(s => s.logs)
+  return { board: b, positions, logs, steps }
 }

--- a/src/boardUtils.js
+++ b/src/boardUtils.js
@@ -158,26 +158,38 @@ export function nextStepTowards(board, fromRow, fromCol, toRow, toCol) {
 }
 
 export function moveGoblinsTowardsHero(board, hero, goblinPositions) {
-  const copy = board.map(row => row.map(t => ({ ...t })));
-  const newPositions = goblinPositions.map(p => ({ ...p }));
-  goblinPositions.forEach((pos, idx) => {
-    const tile = copy[pos.row][pos.col];
-      const gob = tile.goblin;
-      if (!gob || gob.hp <= 0) return;
-    let r = pos.row;
-    let c = pos.col;
-    for (let step = 0; step < (gob.movement || 1); step++) {
-      const next = nextStepTowards(copy, r, c, hero.row, hero.col);
-      if (!next) break;
-      const { r: nr, c: nc } = next;
-      if (copy[nr][nc].goblin && copy[nr][nc].goblin.hp > 0) break;
-      copy[nr][nc] = { ...copy[nr][nc], goblin: gob };
-      copy[r][c] = { ...copy[r][c], goblin: null };
-      r = nr;
-      c = nc;
-      if (r === hero.row && c === hero.col) break;
+  const copy = board.map(row => row.map(t => ({ ...t })))
+  const newPositions = goblinPositions.map(p => ({ ...p }))
+  const logs = []
+
+  // Determine the maximum movement across all goblins
+  const maxMove = Math.max(
+    0,
+    ...goblinPositions.map(pos => {
+      const gob = copy[pos.row][pos.col].goblin
+      return gob && gob.hp > 0 ? gob.movement || 1 : 0
+    }),
+  )
+
+  for (let step = 0; step < maxMove; step++) {
+    for (let idx = 0; idx < goblinPositions.length; idx++) {
+      const pos = newPositions[idx]
+      const tile = copy[pos.row][pos.col]
+      const gob = tile.goblin
+      if (!gob || gob.hp <= 0) continue
+      if (step >= (gob.movement || 1)) continue
+
+      const next = nextStepTowards(copy, pos.row, pos.col, hero.row, hero.col)
+      if (!next) continue
+      const { r: nr, c: nc } = next
+      if (copy[nr][nc].goblin && copy[nr][nc].goblin.hp > 0) continue
+
+      copy[nr][nc] = { ...copy[nr][nc], goblin: gob }
+      copy[pos.row][pos.col] = { ...tile, goblin: null }
+      newPositions[idx] = { row: nr, col: nc }
+      logs.push(`${gob.name} moves toward the hero.`)
     }
-    newPositions[idx] = { row: r, col: c };
-  });
-  return { board: copy, positions: newPositions };
+  }
+
+  return { board: copy, positions: newPositions, logs }
 }


### PR DESCRIPTION
## Summary
- update `moveGoblinsTowardsHero` so monsters move one room at a time and return log messages
- show each monster move during the end turn sequence
- document the sequential monster movement logic in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851ab7d8d0883268d63df7250de15dd