### PR TITLE
Add extra torch surge events

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A horizontal torch bar below the dungeon board counts turns. The torch starts at
 step 0 and drops one step every time you end your turn. A burning torch icon
 marks the current position on the track. Reaching step 20 opens a Game Over
 modal announcing defeat.
-Each end turn logs a short message as the torch advances so you can follow the countdown in the narrative feed. When the torch reaches step 4 every discovered monster now advances one room at a time with a one second pause between each move. Every step is logged so you can track how the dungeon closes in around the hero.
+Each end turn logs a short message as the torch advances so you can follow the countdown in the narrative feed. When the torch reaches steps 4, 8, 10, 13, 15 and 18 every discovered monster surges forward one room at a time with a one second pause between each move. Every step is logged so you can track how the dungeon closes in around the hero.
 
 ### Styling with SCSS
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -157,7 +157,7 @@ function App() {
     }))
     addLog(`${state.hero.name} pauses to regroup at ${roomCode(state.hero.row, state.hero.col)}.`)
     addLog(`Torch advances to ${newTorch}/20.`)
-    if (newTorch === 4) {
+    if ([4, 8, 10, 13, 15, 18].includes(newTorch)) {
       addLog('The goblins surge forward!')
       const { steps } = moveGoblinsTowardsHero(
         state.board,


### PR DESCRIPTION
## Summary
- trigger goblin movement at torch steps 8, 10, 13, 15 and 18
- document the new torch track behavior

## Testing
- `npm run lint` *(fails: 'trap' is not defined)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851c6980678832692a74c07a00d8106